### PR TITLE
chore: prepare repo for public release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,25 @@
-# YClaw Agents environment template
+# ============================================================================
+# YCLAW Configuration
+# ============================================================================
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
 #
-# Copy to `.env` for local development. Leave values blank unless you need the
-# integration locally. Secrets belong in your shell, an untracked `.env`, or
+# REQUIRED to boot the stack via `docker compose up`:
+#   - At least one LLM provider API key (ANTHROPIC_API_KEY recommended)
+#
+# Everything else is optional — leave blank unless you're enabling that
+# integration. Secrets belong in your shell, an untracked .env, or AWS
 # Secrets Manager for deployed environments.
+# ============================================================================
+
+# ---------------------------------------------------------------------------
+# Docker Compose knobs
+# ---------------------------------------------------------------------------
+# Override host ports if 3000/3001/5432/6379/27017 are already in use.
+
+API_PORT=3000                  # Host port for the YCLAW core API
+MC_PORT=3001                   # Host port for Mission Control
+POSTGRES_PASSWORD=yclaw_dev    # Local-only password for the bundled postgres
 
 # ---------------------------------------------------------------------------
 # Core runtime
@@ -12,14 +29,20 @@ NODE_ENV=development
 PORT=3000
 YCLAW_WEBHOOK_PORT=3100
 YCLAW_LOG_LEVEL=info           # Core runtime logger level
-LOG_LEVEL=info                # ACPX logger level
+LOG_LEVEL=info                 # ACPX logger level
 YCLAW_LOG_DIR=
 
-REDIS_URL=redis://localhost:6379
-MONGODB_URI=mongodb://localhost:27017/yclaw
+# Database connection strings — defaults match the bundled docker-compose
+# service hostnames. If you point YCLAW at external databases, set these to
+# your hosted endpoints.
+REDIS_URL=redis://redis:6379
+MONGODB_URI=mongodb://mongo:27017/yclaw
 MONGODB_DB=yclaw_agents
 YCLAW_DB_NAME=                 # Legacy fallback used by the audit logger
-MEMORY_DATABASE_URL=          # Postgres URL for @yclaw/memory
+MEMORY_DATABASE_URL=postgresql://yclaw:yclaw_dev@postgres:5432/yclaw_memory
+
+YCLAW_OBJECT_STORE_PATH=./data/objects   # Local file backend for IObjectStore
+YCLAW_SETUP_TOKEN=             # One-time bootstrap token for root operator setup
 
 YCLAW_API_KEY=                 # Protects core /api routes when set
 YCLAW_API_URL=http://localhost:3000
@@ -33,12 +56,19 @@ ECS_TASK_ARN=
 # LLM providers and routing
 # ---------------------------------------------------------------------------
 
-ANTHROPIC_API_KEY=
-ANTHROPIC_OAUTH_TOKEN=        # (optional) OAuth bearer token — alternative to ANTHROPIC_API_KEY
-OPENAI_API_KEY=
+# LLM provider keys — at least one is required to boot.
+ANTHROPIC_API_KEY=             # Get from console.anthropic.com (recommended default)
+ANTHROPIC_OAUTH_TOKEN=         # (optional) OAuth bearer token — alternative to ANTHROPIC_API_KEY
+OPENAI_API_KEY=                # Get from platform.openai.com
 OPENROUTER_API_KEY=
 XAI_API_KEY=
 GEMINI_API_KEY=
+
+# Default LLM routing (overridable per-agent in departments/*.yaml)
+LLM_PROVIDER=anthropic
+LLM_MODEL=claude-opus-4-6
+ONBOARDING_LLM_PROVIDER=       # Defaults to LLM_PROVIDER
+ONBOARDING_MODEL=              # Defaults to LLM_MODEL
 
 # Azure OpenAI — set these instead of OPENAI_API_KEY to route via Azure (optional)
 AZURE_OPENAI_API_KEY=
@@ -159,7 +189,7 @@ VERCEL_ORG_ID=
 VERCEL_PROJECT_ID=
 
 # ---------------------------------------------------------------------------
-# Slack
+# Slack / Discord
 # ---------------------------------------------------------------------------
 
 SLACK_BOT_TOKEN=
@@ -167,6 +197,18 @@ SLACK_SIGNING_SECRET=
 SLACK_WEBHOOK_URL=
 SLACK_ALLOWED_CHANNEL_IDS=
 YCLAW_ALERTS_CHANNEL=#yclaw-alerts        # Slack channel for escalation alerts (optional)
+
+DISCORD_BOT_TOKEN=
+
+# ---------------------------------------------------------------------------
+# AO orchestration (optional)
+# ---------------------------------------------------------------------------
+
+AO_SERVICE_URL=
+AO_AUTH_TOKEN=
+AO_DEFAULT_AGENT=
+AO_SLACK_CHANNEL=
+AO_SLACK_NOTIFICATIONS=false
 
 # ---------------------------------------------------------------------------
 # X / social publishing

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@
 # Docker Compose knobs
 # ---------------------------------------------------------------------------
 # Override host ports if 3000/3001/5432/6379/27017 are already in use.
+#
+# NOTE: Default database URLs below use Docker Compose service hostnames
+# (mongo, redis, postgres). If running outside Docker, change these to
+# localhost or your hosted database endpoints.
 
 API_PORT=3000                  # Host port for the YCLAW core API
 MC_PORT=3001                   # Host port for Mission Control
@@ -41,7 +45,7 @@ MONGODB_DB=yclaw_agents
 YCLAW_DB_NAME=                 # Legacy fallback used by the audit logger
 MEMORY_DATABASE_URL=postgresql://yclaw:yclaw_dev@postgres:5432/yclaw_memory
 
-YCLAW_OBJECT_STORE_PATH=./data/objects   # Local file backend for IObjectStore
+YCLAW_OBJECT_STORE_PATH=/app/data/objects   # Absolute path inside the container — local file backend for IObjectStore
 YCLAW_SETUP_TOKEN=             # One-time bootstrap token for root operator setup
 
 YCLAW_API_KEY=                 # Protects core /api routes when set
@@ -139,7 +143,9 @@ ROOT_API_KEY=                              # API key provisioned for the root op
 # Mission Control — NextAuth
 # ---------------------------------------------------------------------------
 
-NEXTAUTH_SECRET=                           # openssl rand -base64 32
+# NextAuth session encryption — REQUIRED for Mission Control login.
+# Generate a secret: openssl rand -base64 32
+NEXTAUTH_SECRET=
 NEXTAUTH_URL=http://localhost:3001         # Must match MC's public URL
 
 # ---------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -247,6 +247,15 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 SES_FROM_ADDRESS=
 
+# S3 object storage (when SECRET_BACKEND/IObjectStore is set to S3)
+YCLAW_S3_BUCKET=
+YCLAW_S3_PREFIX=
+
+# Legacy AWS Secrets Manager prefix (used by AwsSecretsProvider — note
+# the singular form; the newer secret-backends/aws.ts uses AWS_SECRETS_PREFIX
+# in the "Integration Secret Backend" section below).
+AWS_SECRET_PREFIX=yclaw/
+
 # ---------------------------------------------------------------------------
 # Wallets and on-chain data
 # ---------------------------------------------------------------------------

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/GravitonINC/YClaw/security/advisories/new
+    url: https://github.com/YClawAI/yclaw/security/advisories/new
     about: Report security vulnerabilities privately (do NOT open a public issue)
   - name: Documentation
-    url: https://github.com/GravitonINC/YClaw/tree/main/docs
+    url: https://github.com/YClawAI/yclaw/tree/main/docs
     about: Check the docs before opening an issue

--- a/AI-HANDSHAKE.md
+++ b/AI-HANDSHAKE.md
@@ -6,7 +6,7 @@
 
 You already have an AI assistant. It knows your business — your mission, your priorities, your brand, your tech stack, who's in charge. YCLAW agents need all that same context to be useful.
 
-The AI Handshake bridges the gap: your existing AI generates a structured onboarding packet that YCLAW consumes to program its agents. No forms, no 50-question wizards, no copying and pasting between docs.
+The AI Handshake bridges the gap: your existing AI sets up YCLAW using the built-in CLI and onboarding flow, programming the agents with your org's context. No forms, no 50-question wizards, no copying and pasting between docs.
 
 **Your AI already knows. YCLAW just needs it to write it down.**
 
@@ -16,132 +16,92 @@ The AI Handshake bridges the gap: your existing AI generates a structured onboar
 ```bash
 git clone https://github.com/YClawAI/yclaw.git && cd yclaw
 cp .env.example .env    # add your LLM API key
-docker compose up -d
+docker compose up -d --build
 ```
 
-### Step 2: Give Your AI the Handshake Prompt
-Copy the contents of `ONBOARDING_PROMPT.md` and paste it into whatever AI you already use — Claude, ChatGPT, Cursor, Codex, Gemini, OpenClaw, anything with context about your organization.
-
-Your AI will generate `yclaw-init.yaml` — a structured file containing everything YCLAW agents need to know about your org.
-
-### Step 3: Import and Boot
+### Step 2: Run the CLI Setup
 ```bash
-./scripts/onboard.sh --from yclaw-init.yaml
+npx yclaw init                    # Guided wizard — infrastructure, channels, LLM, networking
+npx yclaw doctor                  # Preflight validation — checks all prerequisites
+npx yclaw deploy                  # Deploy from generated config
 ```
 
-This generates all the prompt files your agents load on every execution:
-- `prompts/mission_statement.md` — what your org is and believes
-- `prompts/chain-of-command.md` — who's in charge, escalation rules
-- `prompts/protocol-overview.md` — what you build, technically
-- `prompts/brand-voice.md` — how agents communicate externally
-- `prompts/executive-directive.md` — current priorities and KPIs
-- `prompts/engineering-standards.md` — dev standards and conventions
-- `departments/*/agent.yaml` — agent configs with triggers, actions, prompts
-- `departments/*-workflow.md` — per-agent workflow instructions
+The `init` wizard walks through:
+1. **Purpose** — evaluate locally, small team, or production org
+2. **Infrastructure** — Docker Compose, AWS, GCP, K8s
+3. **Channels** — Discord, Slack, Telegram, Twitter/X
+4. **LLM Provider** — Anthropic, OpenAI, OpenRouter, local models
+5. **Networking** — local only, Tailscale, VPN, public
+6. **Review** — generates `yclaw.config.yaml` for approval
 
-### Step 4: Validate and Go Live
+### Step 3: Onboarding — Program Your Agents
+
+Once deployed, the onboarding API guides your AI through 6 stages:
+
+| Stage | What happens | What gets generated |
+|-------|-------------|-------------------|
+| 1. **Org Framing** | Mission, priorities, brand voice, departments, tools | `org_profile`, `priorities`, `brand_voice` artifacts |
+| 2. **Ingestion** | Upload docs, GitHub repos, URLs, text | Indexed context for agent memory |
+| 3. **Departments** | Review and customize department configs | Department YAML + workflow prompts |
+| 4. **Operators** | Invite additional operators | Operator accounts with RBAC tiers |
+| 5. **Validation** | Verify all configs are sound | Validation report |
+| 6. **Complete** | Agents boot with real context | Live agents |
+
+The onboarding service lives at `POST /v1/onboarding/*` and is driven by authenticated API calls. Your AI assistant hits these endpoints to progress through each stage.
+
+See [docs/onboarding.md](docs/onboarding.md) for the full API reference.
+
+### Step 4: First Operator Bootstrap
+
+On first boot with zero operators:
 ```bash
-./scripts/validate.sh     # structural + semantic + runtime checks
-./scripts/activate.sh     # agents boot with YOUR context
+curl -X POST http://localhost:3000/v1/operators/bootstrap \
+  -H "Authorization: Bearer $YCLAW_SETUP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Your Name", "email": "you@example.com"}'
 ```
 
-## Why This Works
+This creates the root operator and returns an API key (shown once). The bootstrap endpoint self-disables after first use.
 
-Traditional onboarding asks YOU to fill in forms. But you hired an AI assistant precisely so you don't have to do that. The Handshake lets your AI do what it's good at — synthesizing everything it knows about you into a structured format another system can consume.
+## The 4-Layer Context Cache
 
-The result: YCLAW agents that actually understand your business from minute one.
+Every agent execution builds its system prompt from 4 layers:
 
-## The Onboarding Packet Schema
+| Layer | What | Source | Caching |
+|-------|------|--------|---------|
+| **Layer 1** | Global static — `mission_statement.md`, `chain-of-command.md`, `protocol-overview.md` | `prompts/` directory | Cached (ephemeral) |
+| **Layer 2** | Department/role — `brand-voice.md`, `executive-directive.md`, `*-workflow.md` | `prompts/` directory | Cached (ephemeral) |
+| **Layer 3** | Memory — org memory, department memory, agent memory | PostgreSQL | Cached (semi-static) |
+| **Layer 4** | Dynamic — auto-recall snippets, task payload, event data | Per-execution | Not cached |
 
-Your AI generates a YAML file matching this structure:
-
-```yaml
-org:
-  name: "Your Org Name"
-  mission: |
-    What your organization does, why it exists, what it believes.
-    This becomes mission_statement.md — loaded by every agent on every execution.
-    Be specific. This is the soul of your agents.
-  
-  chain_of_command: |
-    Who the human decision-makers are.
-    Authority hierarchy. Escalation rules.
-    What agents can decide autonomously vs what needs human approval.
-  
-  product_overview: |
-    Technical description of what you build.
-    Architecture, stack, key systems, APIs.
-    Agents reference this when making technical decisions.
-  
-  brand_voice: |
-    How agents should communicate externally.
-    Tone, vocabulary, examples of good/bad copy.
-    What to say, what never to say.
-  
-  priorities: |
-    Current strategic priorities. What matters THIS quarter.
-    KPIs, deadlines, constraints, risks.
-    Updated regularly — this is the executive directive.
-  
-  engineering_standards: |
-    Coding standards, testing requirements, PR process.
-    Architecture patterns, security rules, deployment practices.
-    What "good code" means in your org.
-
-departments:
-  - name: executive
-    agents:
-      - name: strategist
-        description: "Sets priorities, coordinates across departments"
-        model: claude-sonnet-4-20250514
-        
-  - name: development  
-    agents:
-      - name: architect
-        description: "Technical lead, plans and reviews"
-        model: claude-sonnet-4-20250514
-      - name: builder
-        description: "Executes code tasks from architect specs"
-        model: claude-sonnet-4-20250514
-
-  - name: marketing
-    agents:
-      - name: ember
-        description: "Social media, content creation"
-        model: claude-sonnet-4-20250514
-
-# Optional: sources for deeper context
-sources:
-  websites:
-    - https://yoursite.com
-  github_repos:
-    - https://github.com/your-org/your-repo
-  documents:
-    - path/to/brand-guide.pdf
-    - path/to/strategy-doc.md
-```
+The onboarding flow generates the Layer 1 and 2 prompt files and seeds Layer 3 memory. This is what makes agents actually understand your business instead of being generic shells.
 
 ## What Gets Generated
 
-The onboarding script reads your packet and generates the exact files the 4-layer context cache loads:
+After onboarding, your `prompts/` directory contains:
 
-| Layer | Files | Purpose |
-|-------|-------|---------|
-| **Layer 1 (Global)** | `mission_statement.md`, `chain-of-command.md`, `protocol-overview.md` | Loaded by EVERY agent, EVERY execution |
-| **Layer 2 (Role)** | `brand-voice.md`, `executive-directive.md`, `engineering-standards.md`, `*-workflow.md` | Per-department/agent prompts |
-| **Layer 3 (Memory)** | Postgres records | Org memory, department memory, agent memory |
-| **Layer 4 (Dynamic)** | Auto-recall + task data | Changes every execution |
+| File | Generated from | Loaded by |
+|------|---------------|-----------|
+| `mission_statement.md` | "What does your org do?" | Every agent, every execution |
+| `chain-of-command.md` | "Who's in charge?" | Every agent, every execution |
+| `protocol-overview.md` | "What do you build?" | Every agent, every execution |
+| `brand-voice.md` | "How should agents communicate?" | Marketing, support agents |
+| `executive-directive.md` | "Current priorities?" | Strategist + downstream |
+| `engineering-standards.md` | "Dev standards?" | Development department |
+| `*-workflow.md` | Per-agent role definition | Individual agents |
 
-## Alternate Paths
-
-Not every user's AI will have full org context. The Handshake also supports:
-
-- **Conversational fallback** — `./scripts/onboard.sh` asks questions interactively for any fields your AI couldn't fill
-- **Source ingestion** — point at GitHub repos, websites, or docs and let YCLAW extract context
-- **Direct editing** — all generated files are plain markdown and YAML. Edit them anytime.
+Each agent's YAML config in `departments/*/agent.yaml` lists exactly which prompts it loads.
 
 ## After Onboarding
 
-All context lives in `prompts/` and `departments/`. These are just files. Your AI assistant (or you) can edit them at any time. Changes are picked up on next agent execution or via reload.
+All context lives in `prompts/` and `departments/`. These are just files — your AI assistant (or you) can edit them at any time. Changes are picked up on next agent execution.
 
-The agents will continuously improve their own context through the Claudeception learning system — extracting reusable knowledge from their work and writing it back to memory and skills.
+The agents continuously improve their own context through the Claudeception learning system — extracting reusable knowledge from their work and writing it back to memory and skills.
+
+## Reference Files
+
+- [docs/onboarding.md](docs/onboarding.md) — Full onboarding API reference
+- [docs/quickstart.md](docs/quickstart.md) — Quick start guide
+- [docs/cli.md](docs/cli.md) — CLI command reference
+- [docs/operators.md](docs/operators.md) — Operator RBAC documentation
+- [docs/architecture.md](docs/architecture.md) — System architecture

--- a/AI-HANDSHAKE.md
+++ b/AI-HANDSHAKE.md
@@ -1,0 +1,52 @@
+# The AI Handshake
+
+> The onboarding prompt your AI assistant follows when you hand it this repo.
+>
+> **Status: placeholder.** The full handshake document is being written. For now,
+> this file describes the intended flow so an AI assistant can pattern-match it.
+
+---
+
+## What this file will contain
+
+When you give your AI assistant access to this repo, it should treat this file
+as its onboarding instructions. The full version will walk the assistant through:
+
+1. **Reading the repo** — `README.md`, `prompts/`, `departments/`, `docs/architecture.md`
+2. **Interviewing you** — about your mission, your team, your product, your priorities
+3. **Generating the eight driver files** under `prompts/`:
+   - `mission_statement.md` — why your org exists
+   - `brand-voice.md` — how you sound
+   - `chain-of-command.md` — who's in charge
+   - `executive-directive.md` — current priorities
+   - `protocol-overview.md` — what you do
+   - `content-templates.md` — content formats
+   - `design-system.md` — visual identity
+   - `review-rules.md` — quality gates
+4. **Configuring `.env`** from `.env.example` — surfacing required keys
+5. **Bringing up the stack** — `docker compose up -d --build`
+6. **Verifying** — health checks, Mission Control loads, root operator created
+7. **Tuning** — watching the agents work and adjusting their `departments/<dept>/<agent>.yaml` configs
+
+---
+
+## In the meantime
+
+Until the full handshake document is published, an AI assistant working with
+this repo should:
+
+- Read [`README.md`](./README.md) end-to-end
+- Read [`docs/architecture.md`](./docs/architecture.md) for the system model
+- Read [`docs/quickstart.md`](./docs/quickstart.md) for the deploy flow
+- Read everything in [`prompts/`](./prompts/) as reference examples of what
+  the eight driver files look like for a real deployment
+- Read one or two `departments/*/<agent>.yaml` files to understand the
+  per-agent config schema
+
+Then proceed to interview the operator, generate the org's specific prompt
+files, and bring up the stack via Docker Compose.
+
+---
+
+*This document will be replaced with the full handshake prompt before v0.1.0
+ships. Track progress at [YClawAI/yclaw#1](https://github.com/YClawAI/yclaw/pull/1).*

--- a/AI-HANDSHAKE.md
+++ b/AI-HANDSHAKE.md
@@ -1,52 +1,147 @@
-# The AI Handshake
+# The AI-to-AI Handshake
 
-> The onboarding prompt your AI assistant follows when you hand it this repo.
->
-> **Status: placeholder.** The full handshake document is being written. For now,
-> this file describes the intended flow so an AI assistant can pattern-match it.
+> YCLAW's core onboarding mechanism. Your AI programs our AI.
 
----
+## The Concept
 
-## What this file will contain
+You already have an AI assistant. It knows your business — your mission, your priorities, your brand, your tech stack, who's in charge. YCLAW agents need all that same context to be useful.
 
-When you give your AI assistant access to this repo, it should treat this file
-as its onboarding instructions. The full version will walk the assistant through:
+The AI Handshake bridges the gap: your existing AI generates a structured onboarding packet that YCLAW consumes to program its agents. No forms, no 50-question wizards, no copying and pasting between docs.
 
-1. **Reading the repo** — `README.md`, `prompts/`, `departments/`, `docs/architecture.md`
-2. **Interviewing you** — about your mission, your team, your product, your priorities
-3. **Generating the eight driver files** under `prompts/`:
-   - `mission_statement.md` — why your org exists
-   - `brand-voice.md` — how you sound
-   - `chain-of-command.md` — who's in charge
-   - `executive-directive.md` — current priorities
-   - `protocol-overview.md` — what you do
-   - `content-templates.md` — content formats
-   - `design-system.md` — visual identity
-   - `review-rules.md` — quality gates
-4. **Configuring `.env`** from `.env.example` — surfacing required keys
-5. **Bringing up the stack** — `docker compose up -d --build`
-6. **Verifying** — health checks, Mission Control loads, root operator created
-7. **Tuning** — watching the agents work and adjusting their `departments/<dept>/<agent>.yaml` configs
+**Your AI already knows. YCLAW just needs it to write it down.**
 
----
+## How It Works
 
-## In the meantime
+### Step 1: Install YCLAW
+```bash
+git clone https://github.com/YClawAI/yclaw.git && cd yclaw
+cp .env.example .env    # add your LLM API key
+docker compose up -d
+```
 
-Until the full handshake document is published, an AI assistant working with
-this repo should:
+### Step 2: Give Your AI the Handshake Prompt
+Copy the contents of `ONBOARDING_PROMPT.md` and paste it into whatever AI you already use — Claude, ChatGPT, Cursor, Codex, Gemini, OpenClaw, anything with context about your organization.
 
-- Read [`README.md`](./README.md) end-to-end
-- Read [`docs/architecture.md`](./docs/architecture.md) for the system model
-- Read [`docs/quickstart.md`](./docs/quickstart.md) for the deploy flow
-- Read everything in [`prompts/`](./prompts/) as reference examples of what
-  the eight driver files look like for a real deployment
-- Read one or two `departments/*/<agent>.yaml` files to understand the
-  per-agent config schema
+Your AI will generate `yclaw-init.yaml` — a structured file containing everything YCLAW agents need to know about your org.
 
-Then proceed to interview the operator, generate the org's specific prompt
-files, and bring up the stack via Docker Compose.
+### Step 3: Import and Boot
+```bash
+./scripts/onboard.sh --from yclaw-init.yaml
+```
 
----
+This generates all the prompt files your agents load on every execution:
+- `prompts/mission_statement.md` — what your org is and believes
+- `prompts/chain-of-command.md` — who's in charge, escalation rules
+- `prompts/protocol-overview.md` — what you build, technically
+- `prompts/brand-voice.md` — how agents communicate externally
+- `prompts/executive-directive.md` — current priorities and KPIs
+- `prompts/engineering-standards.md` — dev standards and conventions
+- `departments/*/agent.yaml` — agent configs with triggers, actions, prompts
+- `departments/*-workflow.md` — per-agent workflow instructions
 
-*This document will be replaced with the full handshake prompt before v0.1.0
-ships. Track progress at [YClawAI/yclaw#1](https://github.com/YClawAI/yclaw/pull/1).*
+### Step 4: Validate and Go Live
+```bash
+./scripts/validate.sh     # structural + semantic + runtime checks
+./scripts/activate.sh     # agents boot with YOUR context
+```
+
+## Why This Works
+
+Traditional onboarding asks YOU to fill in forms. But you hired an AI assistant precisely so you don't have to do that. The Handshake lets your AI do what it's good at — synthesizing everything it knows about you into a structured format another system can consume.
+
+The result: YCLAW agents that actually understand your business from minute one.
+
+## The Onboarding Packet Schema
+
+Your AI generates a YAML file matching this structure:
+
+```yaml
+org:
+  name: "Your Org Name"
+  mission: |
+    What your organization does, why it exists, what it believes.
+    This becomes mission_statement.md — loaded by every agent on every execution.
+    Be specific. This is the soul of your agents.
+  
+  chain_of_command: |
+    Who the human decision-makers are.
+    Authority hierarchy. Escalation rules.
+    What agents can decide autonomously vs what needs human approval.
+  
+  product_overview: |
+    Technical description of what you build.
+    Architecture, stack, key systems, APIs.
+    Agents reference this when making technical decisions.
+  
+  brand_voice: |
+    How agents should communicate externally.
+    Tone, vocabulary, examples of good/bad copy.
+    What to say, what never to say.
+  
+  priorities: |
+    Current strategic priorities. What matters THIS quarter.
+    KPIs, deadlines, constraints, risks.
+    Updated regularly — this is the executive directive.
+  
+  engineering_standards: |
+    Coding standards, testing requirements, PR process.
+    Architecture patterns, security rules, deployment practices.
+    What "good code" means in your org.
+
+departments:
+  - name: executive
+    agents:
+      - name: strategist
+        description: "Sets priorities, coordinates across departments"
+        model: claude-sonnet-4-20250514
+        
+  - name: development  
+    agents:
+      - name: architect
+        description: "Technical lead, plans and reviews"
+        model: claude-sonnet-4-20250514
+      - name: builder
+        description: "Executes code tasks from architect specs"
+        model: claude-sonnet-4-20250514
+
+  - name: marketing
+    agents:
+      - name: ember
+        description: "Social media, content creation"
+        model: claude-sonnet-4-20250514
+
+# Optional: sources for deeper context
+sources:
+  websites:
+    - https://yoursite.com
+  github_repos:
+    - https://github.com/your-org/your-repo
+  documents:
+    - path/to/brand-guide.pdf
+    - path/to/strategy-doc.md
+```
+
+## What Gets Generated
+
+The onboarding script reads your packet and generates the exact files the 4-layer context cache loads:
+
+| Layer | Files | Purpose |
+|-------|-------|---------|
+| **Layer 1 (Global)** | `mission_statement.md`, `chain-of-command.md`, `protocol-overview.md` | Loaded by EVERY agent, EVERY execution |
+| **Layer 2 (Role)** | `brand-voice.md`, `executive-directive.md`, `engineering-standards.md`, `*-workflow.md` | Per-department/agent prompts |
+| **Layer 3 (Memory)** | Postgres records | Org memory, department memory, agent memory |
+| **Layer 4 (Dynamic)** | Auto-recall + task data | Changes every execution |
+
+## Alternate Paths
+
+Not every user's AI will have full org context. The Handshake also supports:
+
+- **Conversational fallback** — `./scripts/onboard.sh` asks questions interactively for any fields your AI couldn't fill
+- **Source ingestion** — point at GitHub repos, websites, or docs and let YCLAW extract context
+- **Direct editing** — all generated files are plain markdown and YAML. Edit them anytime.
+
+## After Onboarding
+
+All context lives in `prompts/` and `departments/`. These are just files. Your AI assistant (or you) can edit them at any time. Changes are picked up on next agent execution or via reload.
+
+The agents will continuously improve their own context through the Claudeception learning system — extracting reusable knowledge from their work and writing it back to memory and skills.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,4 +81,4 @@ Initial open-source release. Phases 1-6 of the product framework.
 
 ---
 
-[Unreleased]: https://github.com/GravitonINC/YClaw/compare/main...HEAD
+[Unreleased]: https://github.com/YClawAI/yclaw/compare/main...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ Thanks for your interest in contributing. This guide covers setup, conventions, 
 ## Setup
 
 ```bash
-git clone https://github.com/GravitonINC/YClaw.git
-cd YClaw
+git clone https://github.com/YClawAI/yclaw.git
+cd yclaw
 npm install
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ git clone https://github.com/YClawAI/yclaw.git
 cd yclaw
 cp .env.example .env
 # Edit .env — add ANTHROPIC_API_KEY (or OPENAI_API_KEY)
-docker compose up -d
+docker compose up -d --build
 ```
+
+> **First boot takes 2-3 minutes** while Docker builds the API and dashboard
+> images and the migrate one-shot runs against postgres. Watch progress with
+> `docker compose logs -f api`. Subsequent runs can drop the `--build` flag.
 
 ### Verify
 
@@ -59,6 +63,24 @@ curl -fsS -X POST http://localhost:3000/api/migrate
 ```
 
 Then open Mission Control at **http://localhost:3001**.
+
+### First login
+
+On first boot, the API auto-seeds a root operator and prints its API key to
+stdout (NOT to log files). Find it with:
+
+```bash
+docker compose logs api | grep -A 2 'ROOT OPERATOR API KEY'
+```
+
+Copy the `gzop_live_…` key. At the Mission Control login page, authenticate
+as the root operator using that key. The key is shown only once — store it
+in a password manager.
+
+> **Alternative**: set `ROOT_API_KEY=gzop_live_…` (your own pre-generated
+> key) or `YCLAW_SETUP_TOKEN=<32+ char token>` in `.env` before first boot
+> to skip auto-seeding and bootstrap via `POST /v1/operators/bootstrap`
+> instead. See [`docs/operators.md`](docs/operators.md).
 
 ### What "working" looks like
 

--- a/README.md
+++ b/README.md
@@ -1,359 +1,219 @@
-# 🦞 YCLAW
+# YCLAW
 
-<p align="center">
-  <strong>Your AI assistant just got a company to run.</strong>
-</p>
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](./LICENSE)
+[![Node](https://img.shields.io/badge/node-%3E%3D20-339933.svg)](https://nodejs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6.svg)](https://www.typescriptlang.org)
+[![Docker](https://img.shields.io/badge/docker-compose-2496ED.svg)](https://docs.docker.com/compose/)
 
-<p align="center">
-  An open-source AI org — 12 agents, 6 departments, multi-chain treasury,<br>
-  full governance — steered by YOUR AI assistant through 8 markdown files.<br><br>
-  Extracted from a production system that ran 12 autonomous agents for over a year. This is the open-source engine — v0.1.
-</p>
+> **Open-source AI agent orchestration framework.**
+> Your AI assistant deploys it. Your AI assistant programs it. Your org gets a workforce.
 
-<p align="center">
-  <a href="https://openclaw.ai"><img src="https://img.shields.io/badge/Built%20on-OpenClaw-blue?style=for-the-badge" alt="Built on OpenClaw"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=for-the-badge" alt="License"></a>
-  <a href="https://clawhub.com"><img src="https://img.shields.io/badge/Skills-ClawHub-orange?style=for-the-badge" alt="ClawHub"></a>
-  <a href="https://yclaw.ai"><img src="https://img.shields.io/badge/Web-yclaw.ai-purple?style=for-the-badge" alt="Website"></a>
-  <a href="https://x.com/YClaw_ai"><img src="https://img.shields.io/badge/𝕏-@YClaw%5Fai-black?style=for-the-badge" alt="Twitter"></a>
-  <a href="https://discord.gg/97Fvue9327"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-</p>
-<p align="center">
-  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/Node.js-20%2B-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js"></a>
-  <a href="https://www.typescriptlang.org"><img src="https://img.shields.io/badge/TypeScript-Strict-3178C6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript"></a>
-  <a href="https://www.docker.com"><img src="https://img.shields.io/badge/Docker-Ready-2496ED?style=for-the-badge&logo=docker&logoColor=white" alt="Docker"></a>
-</p>
+---
 
-<p align="center">
-  <a href="docs/quickstart.md">Docs</a>
-</p>
+## What YCLAW Is
+
+YCLAW is an open-source framework for running an organization of AI agents. Your existing AI assistant deploys YCLAW into your environment, then programs the agents using your organization's context (mission, brand voice, chain of command, priorities). Agents are organized into **departments** with role-based access control, an HMAC-signed event bus, and persistent agent memory. YCLAW was extracted from a production system that ran 12 autonomous agents for over a year.
+
+---
+
+## The AI Handshake
+
+Every other agent framework asks **you** to write the agents.
+
+YCLAW asks your **AI assistant** to write them.
+
+Your AI already knows your business — it's been in your terminal, your codebase, your Slack DMs. YCLAW just needs it to write that knowledge down. Hand your assistant this repo, and it will:
+
+1. Read `prompts/` to understand what an org-config file looks like
+2. Interview you about your mission, your team, your product
+3. Generate the eight markdown files that define *your* org
+4. Bring up the stack with `docker compose up`
+5. Watch the agents work and tune their configs
+
+See [`AI-HANDSHAKE.md`](./AI-HANDSHAKE.md) for the full flow your assistant should follow.
 
 ---
 
 ## Quick Start
 
-Prerequisites: [Docker](https://docs.docker.com/get-docker/) and [Node.js 20+](https://nodejs.org).
+```bash
+git clone https://github.com/YClawAI/yclaw.git
+cd yclaw
+cp .env.example .env
+# Edit .env — add ANTHROPIC_API_KEY (or OPENAI_API_KEY)
+docker compose up -d
+```
+
+### Verify
 
 ```bash
-npx yclaw init --preset local-demo
-npx yclaw deploy
+# All five services should be "Up" or "healthy"
+docker compose ps
+
+# Should print: {"status":"ok"}
+curl -fsS http://localhost:3000/health
+
+# One-shot DB migration (idempotent — also runs automatically via the
+# `migrate` service on first boot)
+curl -fsS -X POST http://localhost:3000/api/migrate
 ```
 
-Open [http://localhost:3001](http://localhost:3001). That's Mission Control. Your AI org is running.
+Then open Mission Control at **http://localhost:3001**.
 
-See [docs/quickstart.md](docs/quickstart.md) for the full walkthrough.
+### What "working" looks like
 
----
-
-## What is YCLAW?
-
-Most AI frameworks give you agents. YCLAW gives your AI assistant an **organization** to run.
-
-Your AI assistant ([OpenClaw](https://openclaw.ai)) docks in as the root operator. It doesn't just answer questions — it manages departments, delegates work, tracks treasury across blockchains, and runs the whole operation. You control everything through 8 markdown files.
-
-We didn't build this for a demo day. We built it to run our own company, ran 12 autonomous agents in production for over a year, and open-sourced the engine.
-
-**No telemetry. No phone-home. Your data stays on your infrastructure.**
+| Check | Expected |
+|-------|----------|
+| `docker compose ps` | `mongo`, `redis`, `postgres`, `api`, `dashboard` all healthy |
+| `curl http://localhost:3000/health` | `200 OK`, JSON body |
+| `curl http://localhost:3000/health/ready` | `200 OK`, all dependencies green |
+| Mission Control (`http://localhost:3001`) | Dashboard renders, no console errors |
+| `docker compose logs api` | `Webhook server: http://localhost:3000`, no stack traces |
 
 ---
 
-## 💡 Your AI + Their AI + One Organization
+## Architecture Overview
 
-Everyone has a personal AI assistant now. But yours can't talk to theirs, and neither can actually *run* anything together.
+### Monorepo layout
 
-YCLAW is the shared operating layer. You decide the structure — departments, permissions, chain of command, treasury access — and configure how your AI works alongside your cofounder's, your team's, or your contractors'. Every action is logged: which AI did what, on behalf of which human.
+| Path | Purpose |
+|------|---------|
+| `packages/core` | Runtime engine — agents, operators, events, safety guards |
+| `packages/memory` | PostgreSQL-backed agent memory (`@yclaw/memory`) |
+| `packages/mission-control` | Next.js 14 dashboard (port 3001) |
+| `packages/cli` | `yclaw` CLI — `init`, `doctor`, `deploy`, `status` |
+| `departments/` | Per-department YAML agent configs |
+| `prompts/` | Example markdown driver files (mission, brand voice, etc.) |
+| `deploy/` | Docker Compose and AWS deploy scaffolding |
+| `docs/` | Architecture, configuration, security, deployment guides |
 
-Agent frameworks let one developer orchestrate their own pipelines. YCLAW lets **multiple people, with their own AI assistants, co-operate a single organization** — configured however you want it to work.
-
----
-
-## Customize Your Organization
-
-YCLAW ships with 12 agent roles. To make them yours, edit these 8 driver documents:
-
-| File | What It Defines | Example |
-|------|----------------|---------|
-| `prompts/mission_statement.md` | Why your org exists | Company mission, nonprofit charter, campaign platform |
-| `prompts/brand-voice.md` | How you sound | Tone, personality, language rules |
-| `prompts/chain-of-command.md` | Who's in charge | Authority structure, escalation rules |
-| `prompts/executive-directive.md` | Current priorities | Weekly goals, KPIs, operating rules |
-| `prompts/protocol-overview.md` | What you do | Product description, service overview |
-| `prompts/content-templates.md` | Content formats | Social media templates, posting schedule |
-| `prompts/design-system.md` | Visual identity | Colors, typography, component specs |
-| `prompts/review-rules.md` | Quality gates | What gets auto-published vs needs review |
-
-Edit a file. Push. Your AI org restructures itself. No redeployment. No config hell.
-
----
-
-## The Organization
-
-```
-                         ┌──────────────┐
-                         │  EXECUTIVE   │
-                         │              │
-                         │  Strategist  │  Sets priorities, synthesizes reports
-                         │  Reviewer    │  Brand gate, quality control
-                         └──────┬───────┘
-                                │
-        ┌───────────────┬───────┼───────┬───────────────┬──────────────┐
-        │               │               │               │              │
- ┌──────┴───────┐ ┌─────┴──────┐ ┌──────┴──────┐ ┌─────┴─────┐ ┌─────┴─────┐
- │  MARKETING   │ │ OPERATIONS │ │ DEVELOPMENT │ │  FINANCE  │ │  SUPPORT  │
- │              │ │            │ │             │ │           │ │           │
- │  Ember       │ │  Sentinel  │ │  Architect  │ │ Treasurer │ │  Guide    │
- │  Forge       │ │  Librarian │ │  Designer   │ │           │ │  Keeper   │
- │  Scout       │ │            │ │             │ │           │ │           │
- └──────────────┘ └────────────┘ └─────────────┘ └───────────┘ └───────────┘
-```
-
-| Department | Agents | What they do |
-|------------|--------|-------------|
-| **Executive** | Strategist, Reviewer | Set weekly priorities, synthesize standups, gate all external content |
-| **Development** | Architect, Designer | Review PRs, enforce design systems, coordinate coding tasks |
-| **Marketing** | Ember, Forge, Scout | Create content, generate images/video, monitor competitors |
-| **Operations** | Sentinel, Librarian | Deploy health checks, code quality audits, knowledge curation |
-| **Finance** | Treasurer | Multi-chain treasury monitoring, LLM spend tracking, financial reporting |
-| **Support** | Guide, Keeper | Community moderation, escalated support, email tickets |
-
-Each agent is defined by a YAML config — model, temperature, system prompts, triggers, actions, and event subscriptions. Add a YAML file, add an agent.
-
----
-
-## What Makes This Different
-
-| | Agent Frameworks (CrewAI, LangGraph, AutoGPT) | YCLAW |
-|---|---|---|
-| **What you get** | Agent tasks / chains | A full organization with departments |
-| **Configuration** | Python classes, JSON configs | 8 markdown files a human can read |
-| **Interface** | Your code calls the agent | Your AI assistant IS the operator |
-| **Treasury** | Not included | Multi-chain — Solana, ETH, L2s, TradFi |
-| **Governance** | Basic or none | 4-tier RBAC, HMAC-signed events, audit trails |
-| **Track record** | Mostly demos and prototypes | 12 agents, 1+ year, production |
-
-YCLAW is not an agent framework. It's closer to an operating system for an autonomous company.
-
----
-
-## Key Features
-
-- **AI-operated** — Your [OpenClaw](https://openclaw.ai) assistant docks in as root operator. The assistant is the interface — it manages the fleet, not you. (More AI assistants coming soon — see roadmap.)
-- **Multi-chain treasury** — Track wallets across Solana, Ethereum, L2s, and traditional finance from one operating model. Your AI org understands where the money is.
-- **Self-aware agents** — Every agent knows its own config, source code, execution history, and the full org chart. They reason about their own software.
-- **Autonomous pipeline** — Issues get assigned → code gets written → PRs get reviewed → CI passes → code ships. No human in the loop (unless you want one).
-- **Event-driven coordination** — HMAC-signed Redis event bus. Strategist sends directives, Architect coordinates code changes, Reviewer gates content, Sentinel monitors deploys.
-- **Continuous learning** — Agents extract reusable skills from every non-trivial task. The org gets smarter over time (Claudeception system).
-- **Safety floors** — Immutable safety gates, protected config keys, brand review, outbound security scanning, full audit trails. Agents can evolve, but they can't override their guardrails.
-- **Conversational onboarding** — Guided setup generates org profile, department configs, and brand voice from your answers. Drop files, link repos, paste URLs.
-- **Built-in observability** — Health checks, 17 structured error codes, audit timeline, operator activity tracking.
-
----
-
-## Architecture
+### Service topology
 
 ```
   ┌──────────────────────────────────────────────────────────────┐
   │                      Mission Control                         │
-  │              (Next.js Dashboard — port 3001)                 │
+  │                  (Next.js — port 3001)                       │
   └──────────────────────┬───────────────────────────────────────┘
                          │ HTTP
   ┌──────────────────────┴───────────────────────────────────────┐
   │                       Core Runtime                           │
-  │  ┌─────────┐  ┌──────────┐  ┌──────────┐  ┌─────────────┐  │
-  │  │Operators │  │Onboarding│  │  Agents  │  │Observability│  │
-  │  │  (RBAC)  │  │  (Setup) │  │(12 roles)│  │  (Health)   │  │
-  │  └─────────┘  └──────────┘  └──────────┘  └─────────────┘  │
-  │  ┌─────────┐  ┌──────────┐  ┌──────────┐  ┌─────────────┐  │
-  │  │ Safety  │  │ Review   │  │ Codegen  │  │  Reactions  │  │
-  │  │ Guards  │  │  Gate    │  │(CLI/Pi)  │  │  (Auto-ops) │  │
-  │  └─────────┘  └──────────┘  └──────────┘  └─────────────┘  │
+  │  Operators · Onboarding · Agents · Observability · Safety    │
+  │              Review Gate · Codegen · Reactions               │
   └──────┬──────────────┬───────────────┬───────────────┬───────┘
          │              │               │               │
   ┌──────┴──────┐ ┌─────┴─────┐ ┌──────┴──────┐ ┌─────┴──────┐
   │  MongoDB    │ │   Redis   │ │ PostgreSQL  │ │  Channels  │
-  │ State/Audit │ │Events/KV  │ │   Memory    │ │Slack/Discord│
+  │ State/Audit │ │Events/Bus │ │   Memory    │ │Slack/Disc. │
   └─────────────┘ └───────────┘ └─────────────┘ │Telegram/X  │
                                                  └────────────┘
 ```
 
----
+### Department / agent model
 
-<details>
-<summary><strong>The CLI</strong></summary>
+| Department | Agents | What they do |
+|-----------|--------|-------------|
+| **Executive** | Strategist, Reviewer | Set priorities, synthesize standups, gate external content |
+| **Development** | Architect, Designer | Review PRs, enforce design systems, coordinate codegen |
+| **Marketing** | Ember, Forge, Scout | Author content, generate images/video, monitor competitors |
+| **Operations** | Sentinel, Librarian | Deploy health checks, code-quality audits, knowledge curation |
+| **Finance** | Treasurer | Multi-chain treasury, LLM spend tracking, financial reporting |
+| **Support** | Guide, Keeper | Community moderation, escalated support, email tickets |
 
-```bash
-npx yclaw init          # Guided setup wizard
-npx yclaw doctor        # Preflight validation
-npx yclaw deploy        # Deploy from generated config
-npx yclaw status        # Check system health
-npx yclaw destroy       # Tear down infrastructure
-npx yclaw config validate   # Validate yclaw.config.yaml
-```
+Each agent is a YAML file under `departments/<dept>/<agent>.yaml`. Add a file → add an agent.
 
-| Command | Key Flags | What it does |
-|---------|-----------|-------------|
-| `npx yclaw init` | `--preset`, `--non-interactive`, `--force` | Generate `yclaw.config.yaml` + `.env` |
-| `npx yclaw doctor` | `--json` | Run 10+ diagnostic checks |
-| `npx yclaw deploy` | `--dry-run`, `--detach`, `--dev`, `--skip-verification` | Deploy with selected executor |
-| `npx yclaw destroy` | `--volumes`, `--force` | Stop containers, optionally remove data |
-| `npx yclaw status` | `--json`, `--verbose`, `--api-url`, `--api-key` | Fetch health from running instance |
-| `npx yclaw config validate` | `--config`, `--strict` | Schema-validate config file |
+### Event bus pattern
 
-See [docs/cli.md](docs/cli.md) for the complete reference.
+Agents communicate over an HMAC-signed Redis event bus with schema validation, replay prevention, and a verified `SafeEventContext` projection injected into LLM prompts. Triggers (cron, webhook, slash command, channel message) emit events; agent subscriptions match by topic; the dispatcher routes to the agent's executor (CLI, Pi, or built-in actions).
 
-</details>
+### 4-layer context cache
 
-<details>
-<summary><strong>Supported configurations</strong></summary>
-
-| Component | Options | Default | Status |
-|-----------|---------|---------|--------|
-| State Store | MongoDB | MongoDB | Stable |
-| Event Bus | Redis | Redis | Stable |
-| Memory | PostgreSQL | PostgreSQL | Stable |
-| Object Storage | Local filesystem, S3 | Local | Stable |
-| Channels | Discord, Slack, Telegram, Twitter/X | (user chooses) | Stable |
-| LLM Providers | Anthropic, OpenAI, OpenRouter | Anthropic | Stable |
-| Secrets | `.env` file, AWS Secrets Manager | `.env` | Stable |
-| Deployment | Docker Compose, AWS Terraform | Docker Compose | Stable |
-| Networking | Local, Tailscale, Public | Local | Stable |
-
-See [docs/configuration.md](docs/configuration.md) and [docs/adapters.md](docs/adapters.md).
-
-</details>
-
-<details>
-<summary><strong>Safety and permissions</strong></summary>
-
-Agents can evolve, but guardrails are immutable:
-
-- **Safety floors** — Core files (`safety.ts`, `audit.ts`, `reviewer.ts`, `executor.ts`) cannot be modified by any agent, ever.
-- **Protected config keys** — Agents can't edit their own `department`, `actions`, `triggers`, or `review_bypass`. Attempts trigger critical alerts.
-- **Tiered modification** — Read-only (free), config updates (auto-logged), model/prompt changes (agent-reviewed), code changes (human-reviewed).
-- **Outbound security** — Deterministic regex scanning blocks credential leaks and data exfiltration on every outbound action.
-- **Brand review gate** — All external-facing content passes through the Reviewer agent before publication.
-- **4-tier RBAC** — Root → department head → contributor → observer. Department-scoped permissions with full audit trail.
-- **HMAC-signed event bus** — Every inter-agent event is cryptographically signed. Schema validation prevents injection.
-
-See [docs/security.md](docs/security.md).
-
-</details>
-
-<details>
-<summary><strong>Observability</strong></summary>
-
-- `GET /health` — Liveness (always 200 if process alive)
-- `GET /health/ready` — Readiness (critical deps available?)
-- `GET /v1/observability/health` — Full breakdown with agent counts, task counts, error summary
-- `GET /v1/observability/audit` — Cursor-paginated audit timeline
-- `GET /v1/observability/errors` — Recent errors with codes and suggested fixes
-- 17 structured error codes covering infra, LLM, agent, security, and channel failures
-- `npx yclaw status` CLI with human and JSON output modes
-
-See [docs/observability.md](docs/observability.md).
-
-</details>
-
-<details>
-<summary><strong>Template variables</strong></summary>
-
-Files in `prompts/`, `departments/`, and `docs/` use `{{PLACEHOLDER}}` syntax:
-
-| Variable | Description |
-|----------|-------------|
-| `{{PROJECT_NAME}}` | Your project name |
-| `{{ORG_NAME}}` | GitHub org or username |
-| `{{ORG_DISPLAY_NAME}}` | Human-readable org name |
-| `{{REPO_NAME}}` | Main repository name |
-| `{{PROJECT_DOMAIN}}` | Your project's domain |
-| `{{API_DOMAIN}}` | Agent API endpoint |
-| `{{PROJECT_SLUG}}` | URL-safe project identifier |
-| `{{ORG_HANDLE}}` | Social media handle |
-
-</details>
+LLM calls share a four-layer prompt structure: **(1)** static system prompts, **(2)** persistent agent memory, **(3)** rolling conversation context, **(4)** live tool-use turn. Layers 1-3 are marked with Anthropic `cache_control` so cache hits land on every multi-turn call. See [`docs/PROMPT-SYSTEM.md`](docs/PROMPT-SYSTEM.md).
 
 ---
 
-## Presets
+## Configuration
 
-Skip the wizard with a preset:
+### Where things live
 
-| Preset | What You Get |
-|--------|-------------|
-| `local-demo` | Docker Compose, all-local services, no channels. Evaluation in 5 minutes. |
-| `small-team` | Docker Compose, Slack enabled. Production-ready for small teams. |
-| `aws-production` | AWS managed services (RDS, ElastiCache, S3), Slack + Discord. Full production. |
+| Path | What it controls |
+|------|-----------------|
+| `.env` | Secrets, API keys, DB connection strings, feature flags |
+| `prompts/*.md` | The eight driver files your AI assistant edits to define the org |
+| `departments/<dept>/<agent>.yaml` | Per-agent config — model, prompts, triggers, actions |
+| `yclaw.config.example.yaml` | Infrastructure adapter selection (Mongo/Redis/Postgres/S3/etc.) |
+| `repos/` | Per-repo codegen configs for the autonomous PR pipeline |
 
----
+### Key environment variables
 
-## 🗺️ Roadmap
+| Variable | Required | Default | Notes |
+|----------|---------|---------|-------|
+| `ANTHROPIC_API_KEY` | ✅ one of | — | Or `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `GEMINI_API_KEY` |
+| `MONGODB_URI` | ✅ | `mongodb://mongo:27017/yclaw` | docker-compose hostname |
+| `REDIS_URL` | ✅ | `redis://redis:6379` | docker-compose hostname |
+| `MEMORY_DATABASE_URL` | ✅ | `postgresql://yclaw:yclaw_dev@postgres:5432/yclaw_memory` | docker-compose hostname |
+| `API_PORT` | — | `3000` | Host port for the core API |
+| `MC_PORT` | — | `3001` | Host port for Mission Control |
+| `POSTGRES_PASSWORD` | — | `yclaw_dev` | Local-only password for the bundled postgres |
+| `NEXTAUTH_SECRET` | for MC auth | — | `openssl rand -base64 32` |
 
-| Focus |
-|-------|
-| ✅ Core framework, CLI, Docker Compose, AWS Terraform, onboarding, observability |
-| 🔨 Smarter departments — adaptive task routing, cross-department collaboration, efficiency metrics |
-| 🔌 Bring your own AI — connect OpenClaw, Claude, ChatGPT, Gemini, or any personal AI assistant as operator |
-| ⛓️ DAO integration — on-chain governance across Solana, Ethereum, and L2s |
-| 🎨 Mission Control redesign — real-time agent activity, improved UX, mobile dashboard |
-| 🚀 Speed delivery — faster agent execution, streaming responses, parallel task processing |
-| 🧬 Agent self-upgrading — agents evolve their own prompts, skills, and configurations autonomously |
+See [`.env.example`](./.env.example) for the full list (~120 variables, grouped by integration).
 
-See [ROADMAP.md](ROADMAP.md) for details.
+### Customizing the org
 
----
-
-## Documentation
-
-| Doc | What It Covers |
-|-----|---------------|
-| [Quickstart](docs/quickstart.md) | Zero to running in 15 minutes |
-| [CLI Reference](docs/cli.md) | All commands, flags, and exit codes |
-| [Configuration](docs/configuration.md) | `yclaw.config.yaml` schema reference |
-| [Architecture](docs/architecture.md) | System design, interfaces, data flow |
-| [Operators](docs/operators.md) | RBAC tiers, permissions, invitations |
-| [Onboarding](docs/onboarding.md) | Conversational setup flow |
-| [Observability](docs/observability.md) | Health, errors, audit, debugging |
-| [Security](docs/security.md) | 7 security domains, threat model |
-| [Docker Compose](docs/deployment/docker-compose.md) | Local and VPS deployment |
-| [AWS](docs/deployment/aws.md) | Production AWS deployment |
-| [Adapters](docs/adapters.md) | Building custom channel/store adapters |
+1. Edit `prompts/mission_statement.md`, `prompts/brand-voice.md`, etc.
+2. Edit `departments/<dept>/<agent>.yaml` to change models, triggers, or system prompts
+3. `docker compose restart api` — agents pick up new configs on boot
 
 ---
 
-## Works With
+## Prerequisites
 
-- [OpenClaw](https://openclaw.ai) — The AI assistant that becomes your operator
-- [ClawHub](https://clawhub.com) — Discover and install agent skills
+- **Docker Engine 24+** with **Docker Compose v2** (`docker compose`, not `docker-compose`)
+- **Node.js 20+** — only required for local development outside containers
+- **At least one LLM API key** — Anthropic recommended (`claude-opus-4-6` is the default)
+- **4 GB+ free RAM** — peak: ~3 GB across all five services
+- **Free ports**: `3000` (API), `3001` (Mission Control), `27017` (Mongo), `6379` (Redis), `5432` (Postgres). Override via `API_PORT` / `MC_PORT` in `.env` if needed.
 
 ---
 
-## Disclaimer
+## Troubleshooting
 
-YCLAW is provided "as-is" without warranty of any kind. You are solely responsible for cloud infrastructure costs, actions taken by AI agents, data stored or transmitted through the system, and compliance with applicable laws. The YCLAW authors are not liable for any damages arising from use of this software, including costs from LLM API usage or actions taken by AI agents. See [LICENSE](./LICENSE) for full terms.
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `docker compose up` fails with `bind: address already in use` | Port 3000/3001/5432/6379/27017 already taken | Set `API_PORT=3010` (or any free port) in `.env` and re-run; for DB ports, stop the local service (`brew services stop postgresql`, etc.) |
+| API container restart-loops with `ANTHROPIC_API_KEY missing` | `.env` not populated | `cp .env.example .env` and add a real key |
+| API logs `connect ECONNREFUSED postgres:5432` | Postgres still booting on first run | Wait ~30s; healthcheck will resolve and the API will retry. If it persists, run `docker compose logs postgres` |
+| `/api/memory-status` returns `{"connected":true,"tables":[]}` | Memory migrations never ran | `curl -X POST http://localhost:3000/api/migrate` |
+| Mission Control shows "API unreachable" | API container unhealthy | `docker compose ps` — check the `api` service status; `docker compose logs api` for the stack trace |
+| `mongo` healthcheck fails on Apple Silicon | Outdated `mongo:7` image | `docker compose pull mongo && docker compose up -d` |
+| Stale data after schema change | Old volume contents | `docker compose down -v` (⚠️ deletes all data) then `docker compose up -d` |
 
 ---
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, PR process, and how to build custom adapters.
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full guide. Quick version:
 
----
+```bash
+git clone https://github.com/YClawAI/yclaw.git
+cd yclaw
+npm install
+npm test
+npx tsc -p packages/core/tsconfig.json --noEmit
+```
 
-## Security
-
-YCLAW implements 7 security domains: dependency supply chain, Docker image security, CI/CD pipeline hardening, agent-specific safety gates, runtime container hardening, monitoring/incident response, and HMAC-signed event bus authentication.
-
-See [SECURITY.md](SECURITY.md) for vulnerability reporting and the full security model.
+PRs against `main`. One logical change per commit. Every PR runs the agent-safety, dependency-gate, and security-alerts workflows — protected paths (`packages/core/src/security/**`, workflows, `Dockerfile*`) require an admin label.
 
 ---
 
 ## License
 
-AGPL-3.0-or-later — see [LICENSE](./LICENSE)
+YCLAW is licensed under [**AGPL-3.0-or-later**](./LICENSE).
 
----
+What this means in practice:
+- **You can run YCLAW privately** — no obligations.
+- **You can fork and modify YCLAW** — you must keep your fork AGPL.
+- **If you deploy YCLAW as a network service** that users interact with, you must offer the modified source code to those users (the AGPL §13 network clause).
+- **You cannot relicense** YCLAW as proprietary software.
 
-<p align="center">
-  Created by <a href="https://x.com/TroyMurs">@TroyMurs</a><br>
-  Built on <a href="https://openclaw.ai">OpenClaw</a>
-</p>
+If you need a commercial license without the AGPL §13 obligations, [open a discussion](https://github.com/YClawAI/yclaw/discussions).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,4 +68,4 @@ Agents that get better at their jobs without human intervention.
 
 Timeline is approximate. We ship when it's ready, not when the calendar says so.
 
-Want to help shape the roadmap? [Join the Discord](https://discord.gg/97Fvue9327) or [open a discussion](https://github.com/GravitonINC/YClaw/discussions).
+Want to help shape the roadmap? [Open a discussion](https://github.com/YClawAI/yclaw/discussions).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in this project, please report it
-responsibly via [GitHub Private Security Advisory](https://github.com/GravitonINC/YClaw/security/advisories/new).
+responsibly via [GitHub Private Security Advisory](https://github.com/YClawAI/yclaw/security/advisories/new).
 
 **Do not open public GitHub issues for security vulnerabilities.** Public
 disclosure before a fix is available puts all users at risk. We ask that you

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,171 @@
+# YCLAW — Full-stack local development / evaluation
+#
+# Brings up the entire YCLAW system on a single host:
+#   - mongo       Operational state store
+#   - redis       Event bus + caching
+#   - postgres    Agent memory store (@yclaw/memory)
+#   - api         YCLAW core engine (Node.js, port 3000)
+#   - dashboard   Mission Control UI (Next.js, port 3001)
+#   - migrate     One-shot init that runs DB migrations against the API
+#
+# Usage:
+#   cp .env.example .env       # then add your LLM API key
+#   docker compose up -d
+#   docker compose logs -f api
+#
+# Verify:
+#   curl http://localhost:3000/health        # API liveness
+#   open http://localhost:3001               # Mission Control
+#
+# Tear down (preserves volumes):
+#   docker compose down
+#
+# Tear down + delete data:
+#   docker compose down -v
+#
+# For ECS / Fargate production deployment, see deploy/aws/ and the root Dockerfile.
+
+services:
+  # ─── MongoDB — Operational state store ────────────────────────────────────
+  mongo:
+    image: mongo:7
+    container_name: yclaw-mongo
+    ports:
+      - "127.0.0.1:27017:27017"
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+
+  # ─── Redis — Event bus + cache ────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    container_name: yclaw-redis
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # ─── PostgreSQL — Agent memory store ──────────────────────────────────────
+  # Schema is created by /api/migrate after the API is healthy (see migrate service).
+  # init-memory.sh runs once on first boot to create pgcrypto + grants.
+  postgres:
+    image: postgres:16-alpine
+    container_name: yclaw-postgres
+    environment:
+      POSTGRES_DB: yclaw_memory
+      POSTGRES_USER: yclaw
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-yclaw_dev}
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./deploy/docker-compose/scripts/init-memory.sh:/docker-entrypoint-initdb.d/init-memory.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U yclaw -d yclaw_memory"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # ─── YCLAW Core API ───────────────────────────────────────────────────────
+  # Built from the simplified compose Dockerfile (no codegen CLI bloat).
+  # Departments and prompts are bind-mounted so you can edit them live.
+  api:
+    build:
+      context: .
+      dockerfile: deploy/docker-compose/Dockerfile
+    image: yclaw/core:local
+    container_name: yclaw-api
+    env_file: [.env]
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      PORT: "3000"
+      MONGODB_URI: mongodb://mongo:27017/yclaw
+      REDIS_URL: redis://redis:6379
+      MEMORY_DATABASE_URL: postgresql://yclaw:${POSTGRES_PASSWORD:-yclaw_dev}@postgres:5432/yclaw_memory
+    ports:
+      - "${API_PORT:-3000}:3000"
+    volumes:
+      - ./departments:/app/departments:ro
+      - ./prompts:/app/prompts:ro
+      - api-objects:/app/data/objects
+      - api-logs:/app/logs
+    depends_on:
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3000/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  # ─── One-shot DB migration ────────────────────────────────────────────────
+  # Hits POST /api/migrate after the API is healthy. Idempotent.
+  # Replays packages/memory/migrations/*.sql against the postgres container.
+  migrate:
+    image: curlimages/curl:8.10.1
+    container_name: yclaw-migrate
+    depends_on:
+      api:
+        condition: service_healthy
+    command: ["-fsS", "-X", "POST", "http://api:3000/api/migrate"]
+    restart: "no"
+
+  # ─── Mission Control Dashboard ────────────────────────────────────────────
+  # Next.js standalone build, served on port 3001.
+  dashboard:
+    build:
+      context: .
+      dockerfile: packages/mission-control/Dockerfile
+    image: yclaw/mission-control:local
+    container_name: yclaw-dashboard
+    env_file: [.env]
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      PORT: "3001"
+      HOSTNAME: "0.0.0.0"
+      YCLAW_API_URL: http://api:3000
+      NEXT_PUBLIC_YCLAW_API_URL: http://localhost:${API_PORT:-3000}
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3001}
+    ports:
+      - "${MC_PORT:-3001}:3001"
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3001/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+networks:
+  default:
+    name: yclaw
+
+volumes:
+  mongo-data:
+  redis-data:
+  postgres-data:
+  api-objects:
+  api-logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,10 @@ services:
       REDIS_URL: redis://redis:6379
       MEMORY_DATABASE_URL: postgresql://yclaw:${POSTGRES_PASSWORD:-yclaw_dev}@postgres:5432/yclaw_memory
     ports:
-      - "${API_PORT:-3000}:3000"
+      # Bind to loopback only — exposing on all interfaces would let anyone on
+      # the host network reach the unauthenticated /health endpoint and the
+      # /v1/operators/bootstrap setup window. Use a reverse proxy for public access.
+      - "127.0.0.1:${API_PORT:-3000}:3000"
     volumes:
       - ./departments:/app/departments:ro
       - ./prompts:/app/prompts:ro
@@ -110,6 +113,7 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
+    # curl is installed via apt-get in deploy/docker-compose/Dockerfile (line 36).
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3000/health"]
       interval: 15s
@@ -147,7 +151,10 @@ services:
       NEXT_PUBLIC_YCLAW_API_URL: http://localhost:${API_PORT:-3000}
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3001}
     ports:
-      - "${MC_PORT:-3001}:3001"
+      # Bind to loopback only — Mission Control hosts the operator UI and is
+      # gated by NextAuth, but exposing publicly would put the login form in
+      # front of every host on the LAN. Use a reverse proxy for public access.
+      - "127.0.0.1:${MC_PORT:-3001}:3001"
     depends_on:
       api:
         condition: service_healthy
@@ -155,6 +162,7 @@ services:
     # the NextAuth middleware (PUBLIC_EXACT) and returns 200 the moment Next.js
     # is listening. /api/health is a *deep* check that 503s on a fresh boot
     # because the gateway WebSocket and operator API aren't connected yet.
+    # wget is installed via `apk add` in packages/mission-control/Dockerfile (line 51).
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3001/login"]
       interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,8 +151,12 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    # Liveness check uses /login because it's an exact-match public path in
+    # the NextAuth middleware (PUBLIC_EXACT) and returns 200 the moment Next.js
+    # is listening. /api/health is a *deep* check that 503s on a fresh boot
+    # because the gateway WebSocket and operator API aren't connected yet.
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3001/api/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3001/login"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -484,14 +484,14 @@ coord.* event published to yclaw:stream:coord
 
 | Department | Channel ID | Agents |
 |------------|-----------|--------|
-| executive | `C0AETTBE893` | strategist, reviewer |
-| development | `C0AEV8L9KTQ` | architect, builder, deployer, designer |
-| marketing | `C0AEFSQV0RM` | ember, forge, scout |
-| operations | `C0AEXAJRSV8` | sentinel, signal |
-| finance | `C0AEXAJJ02W` | treasurer |
-| support | `C0AETTB6ACV` | guide, keeper |
-| alerts | `C0AFA847NAD` | escalations |
-| (fallback) | `C0AEQUE8C59` | unknown agents → `#yclaw-general` |
+| executive | `C0000000001` | strategist, reviewer |
+| development | `C0000000002` | architect, builder, deployer, designer |
+| marketing | `C0000000003` | ember, forge, scout |
+| operations | `C0000000004` | sentinel, signal |
+| finance | `C0000000005` | treasurer |
+| support | `C0000000006` | guide, keeper |
+| alerts | `C0000000007` | escalations |
+| (fallback) | `C0000000008` | unknown agents → `#yclaw-general` |
 
 ### Event Handling
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@
 
 ## Internal Reference (from production system)
 
-These docs describe the internal agent runtime extracted from the production system. They may reference features specific to the Gaze Protocol deployment.
+These docs describe the internal agent runtime extracted from the production system that YCLAW was forked from. They may reference deployment-specific features that aren't part of the framework core.
 
 | Doc | Description |
 |-----|-------------|

--- a/docs/security.md
+++ b/docs/security.md
@@ -287,7 +287,7 @@ nonce, and schema version. Labels the source as `verified: true`.
 
 ## Vulnerability Reporting
 
-Report via [GitHub Private Security Advisory](https://github.com/GravitonINC/YClaw/security/advisories/new).
+Report via [GitHub Private Security Advisory](https://github.com/YClawAI/yclaw/security/advisories/new).
 Do not open public issues. Response: 72-hour acknowledgment, 30-day fix target.
 
 See `/SECURITY.md` for full disclosure policy.

--- a/packages/core/src/actions/slack.ts
+++ b/packages/core/src/actions/slack.ts
@@ -74,10 +74,10 @@ export class SlackExecutor implements ActionExecutor {
 
   /** Channel-specific dedup windows (seconds). */
   private static readonly CHANNEL_DEDUP_TTL: Record<string, number> = {
-    'C0AFA847NAD': 7200,  // #yclaw-alerts: 2 hours
-    'C0AETTBE893': 3600,  // #yclaw-executive: 1 hour
-    'C0AEV8L9KTQ': 1800,  // #yclaw-development: 30 min
-    'C0AEFSQV0RM': 1800,  // #yclaw-marketing: 30 min
+    'C0000000007': 7200,  // #yclaw-alerts: 2 hours
+    'C0000000001': 3600,  // #yclaw-executive: 1 hour
+    'C0000000002': 1800,  // #yclaw-development: 30 min
+    'C0000000003': 1800,  // #yclaw-marketing: 30 min
   };
 
   constructor(redis?: Redis | null) {

--- a/packages/core/src/ao/callback.ts
+++ b/packages/core/src/ao/callback.ts
@@ -19,7 +19,7 @@ const PR_POLL_ATTEMPTS = 4;
 const PR_POLL_INTERVAL_MS = 15_000;
 
 // ─── Slack Notifications ──────────────────────────────────────────────────────
-const AO_SLACK_CHANNEL = process.env.AO_SLACK_CHANNEL || 'C0AEV8L9KTQ'; // #yclaw-development
+const AO_SLACK_CHANNEL = process.env.AO_SLACK_CHANNEL || 'C0000000002'; // #yclaw-development
 
 const EVENT_SLACK_MAP: Record<string, { emoji: string; template: (e: AoCallbackEvent) => string }> = {
   'session.started': {

--- a/packages/core/src/builder/dispatcher.ts
+++ b/packages/core/src/builder/dispatcher.ts
@@ -826,7 +826,7 @@ export class BuilderDispatcher {
     const retryable = Math.max(metrics.dlq.depth - permanent, 0);
 
     await this.deps.eventBus.publish('slack', 'alert', {
-      channel: 'C0AFA847NAD',
+      channel: 'C0000000007',
       text: `📋 Builder DLQ Daily Digest\n• Total: ${metrics.dlq.depth}\n• Retryable: ${retryable}\n• Permanent (need manual fix): ${permanent}\n• Top errors: ${this.topErrors(metrics.dlq.entries)}`,
     });
   }

--- a/packages/core/src/reactions/rules.ts
+++ b/packages/core/src/reactions/rules.ts
@@ -43,7 +43,7 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
       action: {
         type: 'slack:message',
         params: {
-          channel: 'C0AFA847NAD', // #yclaw-alerts
+          channel: 'C0000000007', // #yclaw-alerts
           text: '🚨 CI stuck on branch {{branch}} after 2 retries. Workflow: {{workflow}}. Needs human attention: {{url}}',
         },
       },
@@ -76,7 +76,7 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
       action: {
         type: 'slack:message',
         params: {
-          channel: 'C0AFA847NAD',
+          channel: 'C0000000007',
           text: '🚨 Review comments unaddressed on PR #{{pr_number}} for 30+ minutes. Reviewer: {{reviewer}}. {{pr_url}}',
         },
       },
@@ -112,7 +112,7 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
       {
         type: 'slack:message',
         params: {
-          channel: 'C0AEV8L9KTQ', // #yclaw-development
+          channel: 'C0000000002', // #yclaw-development
           text: '🔄 Auto-updating PR #{{pr_number}} branch — was behind master. CI will re-run.',
         },
       },
@@ -158,7 +158,7 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
       {
         type: 'slack:message',
         params: {
-          channel: 'C0AEV8L9KTQ', // #yclaw-development
+          channel: 'C0000000002', // #yclaw-development
           text: '✅ Auto-merged PR #{{pr_number}} ({{head_branch}}) — reviewed by {{reviewer}}',
         },
       },
@@ -199,7 +199,7 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
       {
         type: 'slack:message',
         params: {
-          channel: 'C0AEV8L9KTQ',
+          channel: 'C0000000002',
           text: '✅ Auto-merged PR #{{pr_number}} after approval by {{reviewer}}',
         },
       },
@@ -273,7 +273,7 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
       {
         type: 'slack:message',
         params: {
-          channel: 'C0AEV8L9KTQ', // #yclaw-development
+          channel: 'C0000000002', // #yclaw-development
           text: '✅ Auto-merged PR #{{pr_number}} — Architect comment [APPROVED], CI was green',
         },
       },
@@ -364,7 +364,7 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
       {
         type: 'slack:message',
         params: {
-          channel: 'C0AEV8L9KTQ',
+          channel: 'C0000000002',
           text: '🔄 Stale review detected on PR #{{pr_number}} — requesting Architect re-review after new commits.',
         },
       },

--- a/packages/core/src/services/reconciler.ts
+++ b/packages/core/src/services/reconciler.ts
@@ -273,7 +273,7 @@ export class PRReconciler {
           .map((d) => `• ${d.type}: #${d.target.number} — ${d.reason}`)
           .join("\n");
         await this.deps
-          .notifySlack("C0AEXAJRSV8", `🔄 Reconciler cycle ${cycleId}\n${summary}`)
+          .notifySlack("C0000000004", `🔄 Reconciler cycle ${cycleId}\n${summary}`)
           .catch(() => {});
       }
     } finally {

--- a/packages/core/src/utils/slack-blocks.ts
+++ b/packages/core/src/utils/slack-blocks.ts
@@ -42,16 +42,16 @@ const AGENT_DEPARTMENT: Record<string, string> = {
 // Hard-coded channel IDs avoid API lookups at runtime.
 
 const DEPARTMENT_CHANNEL: Record<string, string> = {
-  executive: 'C0AETTBE893',   // #yclaw-executive
-  development: 'C0AEV8L9KTQ', // #yclaw-development
-  marketing: 'C0AEFSQV0RM',   // #yclaw-marketing
-  operations: 'C0AEXAJRSV8',  // #yclaw-operations
-  finance: 'C0AEXAJJ02W',     // #yclaw-finance
-  support: 'C0AETTB6ACV',     // #yclaw-support
-  alerts: 'C0AFA847NAD',      // #yclaw-alerts
+  executive: 'C0000000001',   // #yclaw-executive
+  development: 'C0000000002', // #yclaw-development
+  marketing: 'C0000000003',   // #yclaw-marketing
+  operations: 'C0000000004',  // #yclaw-operations
+  finance: 'C0000000005',     // #yclaw-finance
+  support: 'C0000000006',     // #yclaw-support
+  alerts: 'C0000000007',      // #yclaw-alerts
 };
 
-const FALLBACK_CHANNEL = 'C0AEQUE8C59'; // #yclaw-general
+const FALLBACK_CHANNEL = 'C0000000008'; // #yclaw-general
 
 /** Alerts channel ID for escalations/blockers. */
 export const ALERTS_CHANNEL = DEPARTMENT_CHANNEL.alerts!;

--- a/packages/core/tests/slack-dedup.test.ts
+++ b/packages/core/tests/slack-dedup.test.ts
@@ -99,7 +99,7 @@ describe('SlackExecutor dedup', () => {
     });
 
     it('uses channel-specific TTL for known channels', async () => {
-      await executor.isDuplicate('C0AFA847NAD', 'Alert'); // #yclaw-alerts → 7200s
+      await executor.isDuplicate('C0000000007', 'Alert'); // #yclaw-alerts → 7200s
       expect(redis.set).toHaveBeenCalledWith(
         expect.stringContaining('slack:dedup:'),
         expect.any(String),

--- a/packages/core/tests/slack-notifier.test.ts
+++ b/packages/core/tests/slack-notifier.test.ts
@@ -46,7 +46,7 @@ function createMockSlack() {
   return {
     execute: vi.fn().mockResolvedValue({
       success: true,
-      data: { ts: '1234567890.123456', channel: 'C0AEV8L9KTQ' },
+      data: { ts: '1234567890.123456', channel: 'C0000000002' },
     }),
   } as any;
 }
@@ -91,39 +91,39 @@ describe('slack-blocks', () => {
 
   describe('getChannelForAgent', () => {
     it('routes development agents to #yclaw-development', () => {
-      expect(getChannelForAgent('builder')).toBe('C0AEV8L9KTQ');
-      expect(getChannelForAgent('architect')).toBe('C0AEV8L9KTQ');
-      expect(getChannelForAgent('deployer')).toBe('C0AEV8L9KTQ');
-      expect(getChannelForAgent('designer')).toBe('C0AEV8L9KTQ');
+      expect(getChannelForAgent('builder')).toBe('C0000000002');
+      expect(getChannelForAgent('architect')).toBe('C0000000002');
+      expect(getChannelForAgent('deployer')).toBe('C0000000002');
+      expect(getChannelForAgent('designer')).toBe('C0000000002');
     });
 
     it('routes executive agents to #yclaw-executive', () => {
-      expect(getChannelForAgent('strategist')).toBe('C0AETTBE893');
-      expect(getChannelForAgent('reviewer')).toBe('C0AETTBE893');
+      expect(getChannelForAgent('strategist')).toBe('C0000000001');
+      expect(getChannelForAgent('reviewer')).toBe('C0000000001');
     });
 
     it('routes marketing agents to #yclaw-marketing', () => {
-      expect(getChannelForAgent('ember')).toBe('C0AEFSQV0RM');
-      expect(getChannelForAgent('forge')).toBe('C0AEFSQV0RM');
-      expect(getChannelForAgent('scout')).toBe('C0AEFSQV0RM');
+      expect(getChannelForAgent('ember')).toBe('C0000000003');
+      expect(getChannelForAgent('forge')).toBe('C0000000003');
+      expect(getChannelForAgent('scout')).toBe('C0000000003');
     });
 
     it('routes operations agents to #yclaw-operations', () => {
-      expect(getChannelForAgent('sentinel')).toBe('C0AEXAJRSV8');
-      expect(getChannelForAgent('signal')).toBe('C0AEXAJRSV8');
+      expect(getChannelForAgent('sentinel')).toBe('C0000000004');
+      expect(getChannelForAgent('signal')).toBe('C0000000004');
     });
 
     it('routes finance agents to #yclaw-finance', () => {
-      expect(getChannelForAgent('treasurer')).toBe('C0AEXAJJ02W');
+      expect(getChannelForAgent('treasurer')).toBe('C0000000005');
     });
 
     it('routes support agents to #yclaw-support', () => {
-      expect(getChannelForAgent('guide')).toBe('C0AETTB6ACV');
-      expect(getChannelForAgent('keeper')).toBe('C0AETTB6ACV');
+      expect(getChannelForAgent('guide')).toBe('C0000000006');
+      expect(getChannelForAgent('keeper')).toBe('C0000000006');
     });
 
     it('returns fallback channel for unknown agents', () => {
-      expect(getChannelForAgent('unknown')).toBe('C0AEQUE8C59');
+      expect(getChannelForAgent('unknown')).toBe('C0000000008');
     });
   });
 
@@ -215,7 +215,7 @@ describe('slack-blocks', () => {
 
   describe('ALERTS_CHANNEL', () => {
     it('is the correct channel ID for #yclaw-alerts', () => {
-      expect(ALERTS_CHANNEL).toBe('C0AFA847NAD');
+      expect(ALERTS_CHANNEL).toBe('C0000000007');
     });
   });
 });
@@ -262,7 +262,7 @@ describe('SlackNotifier', () => {
     await new Promise(r => setTimeout(r, 50));
 
     expect(slack.execute).toHaveBeenCalledWith('message', expect.objectContaining({
-      channel: 'C0AEV8L9KTQ', // #yclaw-development (builder's department)
+      channel: 'C0000000002', // #yclaw-development (builder's department)
       blocks: expect.any(Array),
     }));
   });
@@ -306,7 +306,7 @@ describe('SlackNotifier', () => {
     await new Promise(r => setTimeout(r, 50));
 
     expect(slack.execute).toHaveBeenCalledWith('thread_reply', expect.objectContaining({
-      channel: 'C0AEV8L9KTQ',
+      channel: 'C0000000002',
       threadTs: '1111111111.111111',
     }));
   });
@@ -323,8 +323,8 @@ describe('SlackNotifier', () => {
 
     const calls = slack.execute.mock.calls;
     const channels = calls.map((c: unknown[]) => (c[1] as Record<string, unknown>).channel);
-    expect(channels).toContain('C0AEV8L9KTQ'); // #yclaw-development
-    expect(channels).toContain('C0AFA847NAD');  // #yclaw-alerts
+    expect(channels).toContain('C0000000002'); // #yclaw-development
+    expect(channels).toContain('C0000000007');  // #yclaw-alerts
   });
 
   it('does not double-post if department channel IS #yclaw-alerts', async () => {
@@ -353,7 +353,7 @@ describe('SlackNotifier', () => {
       .mockResolvedValueOnce({ success: false, error: 'thread_not_found' })
       .mockResolvedValueOnce({
         success: true,
-        data: { ts: '2222222222.222222', channel: 'C0AEV8L9KTQ' },
+        data: { ts: '2222222222.222222', channel: 'C0000000002' },
       });
 
     const event = makeEvent('coord.task.completed', 'builder', {
@@ -391,7 +391,7 @@ describe('SlackNotifier', () => {
     await new Promise(r => setTimeout(r, 50));
 
     expect(slack.execute).toHaveBeenCalledWith('message', expect.objectContaining({
-      channel: 'C0AEFSQV0RM', // #yclaw-marketing
+      channel: 'C0000000003', // #yclaw-marketing
     }));
   });
 
@@ -405,7 +405,7 @@ describe('SlackNotifier', () => {
     await new Promise(r => setTimeout(r, 50));
 
     expect(slack.execute).toHaveBeenCalledWith('message', expect.objectContaining({
-      channel: 'C0AEQUE8C59', // #yclaw-general
+      channel: 'C0000000008', // #yclaw-general
     }));
   });
 });

--- a/packages/mission-control/src/app/api/debug/openclaw/route.ts
+++ b/packages/mission-control/src/app/api/debug/openclaw/route.ts
@@ -20,7 +20,7 @@ export async function GET() {
   const denied = checkTier(auth.session, 'root');
   if (denied) return denied;
 
-  const BASE_URL = process.env.OPENCLAW_URL || 'http://10.0.6.101:53847';
+  const BASE_URL = process.env.OPENCLAW_URL || 'http://localhost:53847';
   const TOKEN = process.env.OPENCLAW_GATEWAY_TOKEN || '';
 
   const results: Record<string, unknown> = {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -74,9 +74,9 @@ Exits 0 if clean, 1 if contamination found. Suitable as a CI step.
 Automates VPC peering between MongoDB Atlas and the yclaw VPC. Requires Atlas cluster on M10+ dedicated tier.
 
 ```bash
-export ATLAS_PUBLIC_KEY="oiuixyuo"
-export ATLAS_PRIVATE_KEY="772ab0f3-0e49-4d7b-990b-b24300900307"
-export ATLAS_PROJECT_ID="698ef5785832f6a035da8b5a"
+export ATLAS_PUBLIC_KEY="<your-atlas-public-key>"
+export ATLAS_PRIVATE_KEY="<your-atlas-private-key>"
+export ATLAS_PROJECT_ID="<your-atlas-project-id>"
 ./scripts/setup-atlas-peering.sh
 ```
 

--- a/scripts/setup-atlas-peering.sh
+++ b/scripts/setup-atlas-peering.sh
@@ -15,9 +15,9 @@
 #   - Generate at: Atlas Console → Organization → Access Manager → API Keys
 #
 # Usage:
-#   export ATLAS_PUBLIC_KEY="oiuixyuo"
-#   export ATLAS_PRIVATE_KEY="772ab0f3-0e49-4d7b-990b-b24300900307"
-#   export ATLAS_PROJECT_ID="698ef5785832f6a035da8b5a"
+#   export ATLAS_PUBLIC_KEY="<your-atlas-public-key>"
+#   export ATLAS_PRIVATE_KEY="<your-atlas-private-key>"
+#   export ATLAS_PROJECT_ID="<your-atlas-project-id>"
 #   ./scripts/setup-atlas-peering.sh
 #
 set -euo pipefail

--- a/terraform/mongodb-peering.tf
+++ b/terraform/mongodb-peering.tf
@@ -3,7 +3,7 @@
 # PREREQUISITE: Atlas cluster must be M10+ (dedicated tier). Shared-tier clusters
 # (M0/M2/M5) do NOT support VPC Peering or Private Endpoints.
 #
-# Current state: MongoDB is secured via NAT Gateway IP whitelist (100.28.108.39/32)
+# Current state: MongoDB is secured via NAT Gateway IP whitelist (set your NAT EIP/32)
 # in the Atlas IP Access List. This is the shared-tier alternative.
 #
 # When ready to upgrade to M10+, use the automated setup script:


### PR DESCRIPTION
## Summary

Five-task pre-launch sweep to make `YClawAI/yclaw` ready to go public.

## Changes

### Task 1 — Branding scrub (gaze-agents/Graviton → yclaw/YClawAI)
- 7 doc files updated (README, SECURITY, CONTRIBUTING, CHANGELOG, ROADMAP, docs/README, docs/security, .github/ISSUE_TEMPLATE/config.yml)
- LICENSE Graviton Inc copyright preserved (legal attribution)
- Discord URL removed from ROADMAP (was a private invite link)

### Task 2 — Content security audit
Audited every file in `prompts/` (29), `departments/` (8 yaml + 7 README), `docs/` (24), `scripts/`. All `prompts/` and `departments/` files were already clean (intentional reference deployment content). Findings fixed:

| File | Finding | Fix |
|------|---------|-----|
| `scripts/setup-atlas-peering.sh` | Real Atlas API keys + project ID hardcoded | Replaced with `<placeholder>` strings |
| `scripts/README.md` | Same Atlas credentials in example block | Genericized |
| `docs/COORDINATION.md` | 8 real Slack channel IDs in routing table | Replaced with `C0000000001`–`C0000000008` |
| `packages/core/src/{actions,ao,builder,reactions,services,utils}/...` (8 files) | Same 8 real Slack channel IDs as code defaults / fixtures | Replaced with same placeholders |
| `packages/mission-control/src/app/api/debug/openclaw/route.ts` | Real internal IP `10.0.6.101` as `OPENCLAW_URL` fallback | Replaced with `localhost` |
| `terraform/mongodb-peering.tf` | Real public NAT EIP `100.28.108.39/32` in comment | Genericized |

No `.env` files exist in the repo (only `.env.example`). Verified.

### Task 3 — `docker-compose.yml` (new, repo root)
Brings up the full stack for local dev/eval:
- `mongo` (mongo:7), `redis` (redis:7-alpine), `postgres` (postgres:16-alpine) — all with healthchecks and named volumes
- `api` — built from `deploy/docker-compose/Dockerfile`, depends on all 3 DBs via `service_healthy`
- `dashboard` — built from `packages/mission-control/Dockerfile`, depends on `api`
- `migrate` — one-shot `curlimages/curl` container that POSTs `/api/migrate` after the API is healthy
- All env via `.env`, host ports overridable via `API_PORT` / `MC_PORT`
- Bind-mounts `departments/` and `prompts/` for live editing

### Task 4 — `.env.example` updates
- Added `## Quick Start` header explaining required vs optional
- Added `API_PORT`, `MC_PORT`, `POSTGRES_PASSWORD` for docker-compose knobs
- Database defaults now point to docker-compose service hostnames (`mongo:27017`, `redis:6379`, `postgres:5432`) instead of `localhost`
- Added missing vars discovered via `grep -rhoE 'process\.env\.[A-Z_]+'`: `LLM_PROVIDER`, `LLM_MODEL`, `ONBOARDING_LLM_PROVIDER`, `ONBOARDING_MODEL`, `DISCORD_BOT_TOKEN`, `AO_*`, `YCLAW_OBJECT_STORE_PATH`, `YCLAW_SETUP_TOKEN`

### Task 5 — README rewrite
9 sections per spec: What YCLAW Is → AI Handshake → Quick Start → Architecture Overview → Configuration → Prerequisites → Troubleshooting → Contributing → License. Drops marketing fluff, leads with commands, includes a real troubleshooting table. Forward-references `AI-HANDSHAKE.md` (to be added separately).

## Test plan

- [ ] `cp .env.example .env`, add `ANTHROPIC_API_KEY`, run `docker compose up -d`
- [ ] Verify `docker compose ps` shows all 5 services healthy
- [ ] `curl -fsS http://localhost:3000/health` returns 200
- [ ] `curl -fsS http://localhost:3000/api/memory-status` shows tables created (migrate ran)
- [ ] Mission Control loads at http://localhost:3001
- [ ] `git grep -E 'gaze-agents|GravitonINC|gazeprotocol|C0AETTBE893|10\.0\.6\.101'` returns nothing
- [ ] `npm test` and `npx tsc -p packages/core/tsconfig.json --noEmit` still pass after Slack channel ID fixture updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)