### PR TITLE
fix: resolve 4 CI workflow failures for clean PR checks

### DIFF
--- a/.github/workflows/agent-safety.yml
+++ b/.github/workflows/agent-safety.yml
@@ -20,6 +20,9 @@ jobs:
   check-protected-paths:
     name: Protected Path Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       core: ${{ steps.filter.outputs.core }}
       mc: ${{ steps.filter.outputs.mc }}

--- a/.github/workflows/socket-security.yml
+++ b/.github/workflows/socket-security.yml
@@ -21,5 +21,4 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
-          enable_comment: true
-          enable_block: true
+          mode: diff

--- a/.github/workflows/workflow-change-guard.yml
+++ b/.github/workflows/workflow-change-guard.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - name: Flag security-sensitive file changes
         run: |


### PR DESCRIPTION
## Summary
Fixes 4 failing workflows that fire on every PR:

### 1. Agent Safety Guard
**Problem:** `gh pr view` fails with `Resource not accessible by integration` — missing permissions to read PR labels.
**Fix:** Added `pull-requests: read` permission to the job.

### 2. Workflow Change Guard
**Problem:** `git diff origin/main...HEAD` fails with `fatal: bad revision` — shallow clone doesn't have `origin/main`.
**Fix:** Added `fetch-depth: 0` to checkout step.

### 3. Socket Security Analysis
**Problem:** SocketDev/action API changed — `enable_comment`/`enable_block` are deprecated, `mode` is now required.
**Fix:** Replaced deprecated inputs with `mode: diff`.

### 4. Build & Deploy (Detect Changes)
**Problem:** `dorny/paths-filter` calls GitHub API to list PR files but lacks `pull-requests: read` permission.
**Fix:** Added `pull-requests: read` permission to the changes job.

## Test Plan
- [ ] All 4 workflows pass on this PR
- [ ] `PR Validation / validate` still passes (untouched)
- [ ] Apply `human-approved` label (this PR touches workflow files)