### PR TITLE
fix: 3 patient-zero blockers + postgres SSL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@
 # Everything else is optional — leave blank unless you're enabling that
 # integration. Secrets belong in your shell, an untracked .env, or AWS
 # Secrets Manager for deployed environments.
+#
+# IMPORTANT: Do NOT put inline comments after `=` on any line. Docker Compose's
+# `env_file` parser treats everything after `=` as the value, including any
+# trailing `# comment`. Always put comments on their own line ABOVE the key.
 # ============================================================================
 
 # ---------------------------------------------------------------------------
@@ -21,9 +25,12 @@
 # (mongo, redis, postgres). If running outside Docker, change these to
 # localhost or your hosted database endpoints.
 
-API_PORT=3000                  # Host port for the YCLAW core API
-MC_PORT=3001                   # Host port for Mission Control
-POSTGRES_PASSWORD=yclaw_dev    # Local-only password for the bundled postgres
+# Host port for the YCLAW core API
+API_PORT=3000
+# Host port for Mission Control
+MC_PORT=3001
+# Local-only password for the bundled postgres
+POSTGRES_PASSWORD=yclaw_dev
 
 # ---------------------------------------------------------------------------
 # Core runtime
@@ -32,8 +39,10 @@ POSTGRES_PASSWORD=yclaw_dev    # Local-only password for the bundled postgres
 NODE_ENV=development
 PORT=3000
 YCLAW_WEBHOOK_PORT=3100
-YCLAW_LOG_LEVEL=info           # Core runtime logger level
-LOG_LEVEL=info                 # ACPX logger level
+# Core runtime logger level
+YCLAW_LOG_LEVEL=info
+# ACPX logger level
+LOG_LEVEL=info
 YCLAW_LOG_DIR=
 
 # Database connection strings — defaults match the bundled docker-compose
@@ -42,13 +51,19 @@ YCLAW_LOG_DIR=
 REDIS_URL=redis://redis:6379
 MONGODB_URI=mongodb://mongo:27017/yclaw
 MONGODB_DB=yclaw_agents
-YCLAW_DB_NAME=                 # Legacy fallback used by the audit logger
-MEMORY_DATABASE_URL=postgresql://yclaw:yclaw_dev@postgres:5432/yclaw_memory
+# Legacy fallback used by the audit logger
+YCLAW_DB_NAME=
+# sslmode=disable is required for the bundled postgres container which does
+# not speak SSL. Change to sslmode=require for managed services like RDS.
+MEMORY_DATABASE_URL=postgresql://yclaw:yclaw_dev@postgres:5432/yclaw_memory?sslmode=disable
 
-YCLAW_OBJECT_STORE_PATH=/app/data/objects   # Absolute path inside the container — local file backend for IObjectStore
-YCLAW_SETUP_TOKEN=             # One-time bootstrap token for root operator setup
+# Absolute path inside the container — local file backend for IObjectStore
+YCLAW_OBJECT_STORE_PATH=/app/data/objects
+# One-time bootstrap token for root operator setup
+YCLAW_SETUP_TOKEN=
 
-YCLAW_API_KEY=                 # Protects core /api routes when set
+# Protects core /api routes when set
+YCLAW_API_KEY=
 YCLAW_API_URL=http://localhost:3000
 NEXT_PUBLIC_YCLAW_API_URL=http://localhost:3000
 EMAIL_ALLOWED_DOMAINS=
@@ -61,9 +76,12 @@ ECS_TASK_ARN=
 # ---------------------------------------------------------------------------
 
 # LLM provider keys — at least one is required to boot.
-ANTHROPIC_API_KEY=             # Get from console.anthropic.com (recommended default)
-ANTHROPIC_OAUTH_TOKEN=         # (optional) OAuth bearer token — alternative to ANTHROPIC_API_KEY
-OPENAI_API_KEY=                # Get from platform.openai.com
+# Get from console.anthropic.com (recommended default)
+ANTHROPIC_API_KEY=
+# (optional) OAuth bearer token — alternative to ANTHROPIC_API_KEY
+ANTHROPIC_OAUTH_TOKEN=
+# Get from platform.openai.com
+OPENAI_API_KEY=
 OPENROUTER_API_KEY=
 XAI_API_KEY=
 GEMINI_API_KEY=
@@ -71,26 +89,34 @@ GEMINI_API_KEY=
 # Default LLM routing (overridable per-agent in departments/*.yaml)
 LLM_PROVIDER=anthropic
 LLM_MODEL=claude-opus-4-6
-ONBOARDING_LLM_PROVIDER=       # Defaults to LLM_PROVIDER
-ONBOARDING_MODEL=              # Defaults to LLM_MODEL
+# Defaults to LLM_PROVIDER when blank
+ONBOARDING_LLM_PROVIDER=
+# Defaults to LLM_MODEL when blank
+ONBOARDING_MODEL=
 
 # Azure OpenAI — set these instead of OPENAI_API_KEY to route via Azure (optional)
 AZURE_OPENAI_API_KEY=
-AZURE_OPENAI_ENDPOINT=        # e.g. https://my-resource.openai.azure.com
-AZURE_OPENAI_API_VERSION=     # e.g. 2024-12-01-preview
+# e.g. https://my-resource.openai.azure.com
+AZURE_OPENAI_ENDPOINT=
+# e.g. 2024-12-01-preview
+AZURE_OPENAI_API_VERSION=
 AZURE_OPENAI_RESOURCE_NAME=
 AZURE_OPENAI_BASE_URL=
-AZURE_OPENAI_DEPLOYMENT_NAME_MAP=  # JSON map of model → deployment, e.g. {"gpt-4o":"my-gpt4o"}
+# JSON map of model → deployment, e.g. {"gpt-4o":"my-gpt4o"}
+AZURE_OPENAI_DEPLOYMENT_NAME_MAP=
 
-LITELLM_PROXY_URL=            # Optional OpenAI-compatible proxy base URL
+# Optional OpenAI-compatible proxy base URL
+LITELLM_PROXY_URL=
 LITELLM_API_KEY=
-LITELLM_DATABASE_URL=         # Used by the LiteLLM proxy task definition
+# Used by the LiteLLM proxy task definition
+LITELLM_DATABASE_URL=
 
 # ---------------------------------------------------------------------------
 # Codegen, ACPX, and Builder tuning
 # ---------------------------------------------------------------------------
 
-EXECUTOR_TYPE=pi              # pi | cli | acp (deprecated) | auto
+# pi | cli | acp (deprecated) | auto
+EXECUTOR_TYPE=pi
 # Legacy: ACPX_SERVICE_URL and ACPX_API_KEY removed — Pi replaces ACP
 PI_CODING_AGENT_ENABLED=true
 PI_DEFAULT_MODEL=claude-opus-4-6
@@ -119,25 +145,34 @@ BUDGET_ENFORCEMENT_ENABLED=true
 # Feature flags
 # ---------------------------------------------------------------------------
 
-FF_PROMPT_CACHING=true         # Prompt caching on LLM calls (default: true; set false to disable)
-FF_CONTEXT_COMPRESSION=false   # Compress conversation context before LLM call (default: false)
-FF_MEMORY_SCANNER=false        # Scan agent memory writes for sensitive content (default: false)
-FF_OBSIDIAN_GATEWAY=false      # Write agent knowledge to Obsidian vault (default: false)
+# Prompt caching on LLM calls (default: true; set false to disable)
+FF_PROMPT_CACHING=true
+# Compress conversation context before LLM call (default: false)
+FF_CONTEXT_COMPRESSION=false
+# Scan agent memory writes for sensitive content (default: false)
+FF_MEMORY_SCANNER=false
+# Write agent knowledge to Obsidian vault (default: false)
+FF_OBSIDIAN_GATEWAY=false
 
 # ---------------------------------------------------------------------------
 # Review gate
 # ---------------------------------------------------------------------------
 
-REVIEW_MODEL=claude-sonnet-4-5-20250929    # LLM used by the Reviewer agent
-REVIEW_FAILURE_STRATEGY=FAIL_OPEN          # FAIL_OPEN (default) or FAIL_CLOSED
+# LLM used by the Reviewer agent
+REVIEW_MODEL=claude-sonnet-4-5-20250929
+# FAIL_OPEN (default) or FAIL_CLOSED
+REVIEW_FAILURE_STRATEGY=FAIL_OPEN
 
 # ---------------------------------------------------------------------------
 # Root operator (seed.ts — sets up the initial operator account)
 # ---------------------------------------------------------------------------
 
-ROOT_OPERATOR_NAME=                        # Display name for the root operator
-ROOT_OPERATOR_EMAIL=                       # Email for the root operator account
-ROOT_API_KEY=                              # API key provisioned for the root operator on first seed
+# Display name for the root operator
+ROOT_OPERATOR_NAME=
+# Email for the root operator account
+ROOT_OPERATOR_EMAIL=
+# API key provisioned for the root operator on first seed
+ROOT_API_KEY=
 
 # ---------------------------------------------------------------------------
 # Mission Control — NextAuth
@@ -146,7 +181,8 @@ ROOT_API_KEY=                              # API key provisioned for the root op
 # NextAuth session encryption — REQUIRED for Mission Control login.
 # Generate a secret: openssl rand -base64 32
 NEXTAUTH_SECRET=
-NEXTAUTH_URL=http://localhost:3001         # Must match MC's public URL
+# Must match MC's public URL
+NEXTAUTH_URL=http://localhost:3001
 
 # ---------------------------------------------------------------------------
 # Mission Control
@@ -170,10 +206,12 @@ GATEWAY_SKIP_DEVICE_AUTH=
 
 AGENTHUB_URL=
 AGENTHUB_DISPATCHER_KEY=
-AGENTHUB_WORKER_KEYS=         # JSON map, e.g. {"worker-1":"..."}
+# JSON map, e.g. {"worker-1":"..."}
+AGENTHUB_WORKER_KEYS=
 AGENTHUB_INTERNAL_URL=
 AGENTHUB_MC_API_KEY=
-AGENTHUB_ADMIN_KEY=           # Used by scripts/register-agents.sh
+# Used by scripts/register-agents.sh
+AGENTHUB_ADMIN_KEY=
 
 GROWTH_ENGINE_API_KEY=
 GROWTH_ENGINE_CONFIG_DIR=
@@ -202,7 +240,8 @@ SLACK_BOT_TOKEN=
 SLACK_SIGNING_SECRET=
 SLACK_WEBHOOK_URL=
 SLACK_ALLOWED_CHANNEL_IDS=
-YCLAW_ALERTS_CHANNEL=#yclaw-alerts        # Slack channel for escalation alerts (optional)
+# Slack channel for escalation alerts (optional)
+YCLAW_ALERTS_CHANNEL=#yclaw-alerts
 
 DISCORD_BOT_TOKEN=
 
@@ -228,7 +267,8 @@ TWITTERAPI_IO_KEY=
 
 INSTAGRAM_ACCESS_TOKEN=
 INSTAGRAM_BUSINESS_ID=
-TIKTOK_ACCESS_TOKEN=          # Reserved; runtime support is incomplete
+# Reserved; runtime support is incomplete
+TIKTOK_ACCESS_TOKEN=
 
 # ---------------------------------------------------------------------------
 # Telegram
@@ -270,7 +310,8 @@ SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
 ETH_RPC_URL=https://eth.llamarpc.com
 TREASURY_WALLET_ADDRESS=
 FEE_PAYER_WALLET_ADDRESS=
-WALLET_CONFIG=                # JSON array for Mission Control wallet views
+# JSON array for Mission Control wallet views
+WALLET_CONFIG=
 HELIUS_API_KEY=
 ALCHEMY_API_KEY=
 
@@ -282,7 +323,8 @@ YCLAW_MCP_ENDPOINT=
 REDIS_CLOUD_API_KEY=
 REDIS_CLOUD_SECRET_KEY=
 
-STITCH_API_KEY=                # (optional) Stitch integration API key
+# (optional) Stitch integration API key
+STITCH_API_KEY=
 
 MONGODB_ATLAS_PUBLIC_KEY=
 MONGODB_ATLAS_PRIVATE_KEY=
@@ -305,11 +347,18 @@ FLUX_API_KEY=
 # Integration Secret Backend (Phase 4)
 # ---------------------------------------------------------------------------
 
-SECRET_BACKEND=mongodb            # mongodb | aws | env | file
-INTEGRATION_SECRET_KEY=           # 64-char hex (AES-256 key) — required for mongodb and file backends
-                                  # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-SECRETS_DIR=./data/secrets        # For file backend: where encrypted secret files are stored
-SECRETS_ENV_FILE=.env.integrations  # For env backend: path to env file for credentials
-AWS_SECRETS_PREFIX=yclaw/integrations/  # For aws backend: Secrets Manager name prefix
-YCLAW_AGENTS_URL=http://localhost:3000  # YClaw Agents API for Tier 3 fleet wiring (optional)
-MISSION_CONTROL_URL=http://localhost:3001  # MC URL for ConnectionReporter callbacks
+# mongodb | aws | env | file
+SECRET_BACKEND=mongodb
+# 64-char hex (AES-256 key) — required for mongodb and file backends.
+# Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+INTEGRATION_SECRET_KEY=
+# For file backend: where encrypted secret files are stored
+SECRETS_DIR=./data/secrets
+# For env backend: path to env file for credentials
+SECRETS_ENV_FILE=.env.integrations
+# For aws backend: Secrets Manager name prefix
+AWS_SECRETS_PREFIX=yclaw/integrations/
+# YClaw Agents API for Tier 3 fleet wiring (optional)
+YCLAW_AGENTS_URL=http://localhost:3000
+# MC URL for ConnectionReporter callbacks
+MISSION_CONTROL_URL=http://localhost:3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,12 @@ services:
       PORT: "3000"
       MONGODB_URI: mongodb://mongo:27017/yclaw
       REDIS_URL: redis://redis:6379
-      MEMORY_DATABASE_URL: postgresql://yclaw:${POSTGRES_PASSWORD:-yclaw_dev}@postgres:5432/yclaw_memory
+      # sslmode=disable — the bundled postgres:16-alpine image does not speak
+      # SSL. Without this the core API logs "Memory database unavailable
+      # (The server does not support SSL connections)" and runs without
+      # persistent memory. For managed services (RDS, Neon, etc) drop this
+      # parameter so the API connects with relaxed-cert SSL instead.
+      MEMORY_DATABASE_URL: postgresql://yclaw:${POSTGRES_PASSWORD:-yclaw_dev}@postgres:5432/yclaw_memory?sslmode=disable
     ports:
       # Bind to loopback only — exposing on all interfaces would let anyone on
       # the host network reach the unauthenticated /health endpoint and the

--- a/packages/core/src/bootstrap/services.ts
+++ b/packages/core/src/bootstrap/services.ts
@@ -247,10 +247,14 @@ export async function initServices(infrastructure?: Infrastructure, yclawConfig?
   const memoryDbUrl = process.env.MEMORY_DATABASE_URL;
   if (memoryDbUrl) {
     try {
-      const cleanDbUrl = memoryDbUrl.replace(/[?&]sslmode=[^&]+/, '');
+      // Respect sslmode=disable in the connection string so the bundled
+      // postgres container (which has no SSL) works out of the box. Any
+      // other sslmode — or no sslmode at all — falls back to relaxed SSL,
+      // which is what managed services like RDS need (self-signed certs).
+      const disableSsl = /[?&]sslmode=disable(?:&|$)/.test(memoryDbUrl);
       memoryPool = new Pool({
-        connectionString: cleanDbUrl,
-        ssl: { rejectUnauthorized: false },
+        connectionString: memoryDbUrl,
+        ssl: disableSsl ? false : { rejectUnauthorized: false },
         min: 2,
         max: 5,
         idleTimeoutMillis: 30_000,
@@ -416,9 +420,19 @@ export async function initServices(infrastructure?: Infrastructure, yclawConfig?
       const onboardingStore = new OnboardingStore(db);
       await onboardingStore.ensureIndexes();
 
-      // Fix: onboarding-specific override takes priority over global
-      const llmProvider = process.env.ONBOARDING_LLM_PROVIDER ?? process.env.LLM_PROVIDER ?? 'anthropic';
-      const llmModel = process.env.ONBOARDING_MODEL ?? process.env.LLM_MODEL ?? 'claude-sonnet-4-20250514';
+      // Onboarding-specific override takes priority over global.
+      // Use `||` (not `??`) so that empty strings — which are the common state
+      // when a user copies .env.example and leaves the override blank — fall
+      // back to the global LLM_PROVIDER / LLM_MODEL instead of being passed
+      // through as an unknown provider.
+      const llmProvider =
+        process.env.ONBOARDING_LLM_PROVIDER?.trim() ||
+        process.env.LLM_PROVIDER?.trim() ||
+        'anthropic';
+      const llmModel =
+        process.env.ONBOARDING_MODEL?.trim() ||
+        process.env.LLM_MODEL?.trim() ||
+        'claude-sonnet-4-20250514';
       const onboardingProvider = createProvider({
         provider: llmProvider as 'anthropic' | 'openrouter' | 'ollama',
         model: llmModel,

--- a/packages/core/src/operators/audit-logger.ts
+++ b/packages/core/src/operators/audit-logger.ts
@@ -29,11 +29,13 @@ export class OperatorAuditLogger {
   }
 
   async ensureIndexes(): Promise<void> {
-    await this.collection.createIndex({ timestamp: 1 });
     await this.collection.createIndex({ operatorId: 1 });
     await this.collection.createIndex({ action: 1 });
     await this.collection.createIndex({ 'resource.type': 1, 'resource.id': 1 });
-    // TTL: auto-delete after 90 days
+    // TTL: auto-delete after 90 days. This also serves as the timestamp index
+    // for sort queries — no separate { timestamp: 1 } index needed, and defining
+    // both would conflict (MongoDB rejects two indexes on the same key with
+    // different names/options).
     await this.collection.createIndex(
       { timestamp: 1 },
       { expireAfterSeconds: 90 * 24 * 60 * 60, name: 'ttl_90d' },

--- a/packages/core/src/triggers/webhook.ts
+++ b/packages/core/src/triggers/webhook.ts
@@ -7,7 +7,13 @@ const API_KEY = process.env.YCLAW_API_KEY || '';
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 /**
- * Check whether a request IP is from a loopback or RFC1918 private network.
+ * Check whether a request IP is internal-only:
+ *   - IPv4 loopback (127.0.0.1)
+ *   - IPv6 loopback (::1)
+ *   - RFC1918 private ranges (10/8, 172.16/12, 192.168/16)
+ *   - IPv4 link-local (169.254/16)
+ *   - IPv6 unique local addresses (fc00::/7)
+ *
  * Used to gate internal-only endpoints like /api/migrate, which must be
  * reachable from the sibling compose container (Docker bridge: 172.16/12)
  * but never from the public internet.

--- a/packages/core/src/triggers/webhook.ts
+++ b/packages/core/src/triggers/webhook.ts
@@ -6,6 +6,30 @@ import type { Server } from 'node:http';
 const API_KEY = process.env.YCLAW_API_KEY || '';
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
+/**
+ * Check whether a request IP is from a loopback or RFC1918 private network.
+ * Used to gate internal-only endpoints like /api/migrate, which must be
+ * reachable from the sibling compose container (Docker bridge: 172.16/12)
+ * but never from the public internet.
+ */
+function isInternalIp(ip: string): boolean {
+  // Strip IPv6-mapped IPv4 prefix (::ffff:10.0.0.1 → 10.0.0.1)
+  const addr = ip.replace(/^::ffff:/, '');
+  if (addr === '127.0.0.1' || addr === '::1' || addr === 'localhost') return true;
+  if (addr.startsWith('10.')) return true;
+  if (addr.startsWith('192.168.')) return true;
+  if (addr.startsWith('169.254.')) return true;
+  // 172.16.0.0/12 (Docker default bridge range)
+  const m = /^172\.(\d+)\./.exec(addr);
+  if (m?.[1]) {
+    const second = parseInt(m[1], 10);
+    if (second >= 16 && second <= 31) return true;
+  }
+  // IPv6 unique local addresses fc00::/7
+  if (addr.startsWith('fc') || addr.startsWith('fd')) return true;
+  return false;
+}
+
 /** Middleware that requires a valid API key in the x-api-key header. */
 function requireApiKey(req: Request, res: Response, next: NextFunction): void {
   if (!API_KEY) {
@@ -88,6 +112,26 @@ export class WebhookServer {
       res.json({ status: 'ok', timestamp: new Date().toISOString() });
     });
 
+    // Trust the first proxy hop so req.ip reflects the real client address
+    // when the API sits behind a reverse proxy (compose sidecar, ALB, etc).
+    this.app.set('trust proxy', 'loopback, linklocal, uniquelocal');
+
+    // ─── Internal-only gate for /api/migrate ────────────────────────────
+    // Schema migration is idempotent and triggered by the `migrate` sidecar
+    // in docker-compose. It must NOT require the operator API key (patient
+    // zero doesn't have one yet), but also must NOT be reachable from the
+    // public internet. Gate it to loopback / RFC1918 ranges only.
+    this.app.use((req: Request, res: Response, next: NextFunction) => {
+      if (req.path !== '/api/migrate') return next();
+      const ip = req.ip || (req as unknown as { connection?: { remoteAddress?: string } }).connection?.remoteAddress || '';
+      if (!isInternalIp(ip)) {
+        this.log.warn('Rejected /api/migrate from non-internal IP', { ip });
+        res.status(403).json({ success: false, error: 'Forbidden: /api/migrate is internal-only' });
+        return;
+      }
+      next();
+    });
+
     // ─── API Key Authentication for all routes except /health ──────────
     this.app.use((req: Request, res: Response, next: NextFunction) => {
       if (req.path === '/health' || req.path === '/health/infra') return next();
@@ -96,6 +140,7 @@ export class WebhookServer {
       if (req.path.startsWith('/slack/')) return next(); // Slack uses HMAC signature verification
       if (req.path.startsWith('/v1/')) return next(); // /v1/* uses operator Bearer auth, not legacy x-api-key
       if (req.path === '/api/ao/callback') return next(); // AO callback uses X-AO-TOKEN auth in its own middleware
+      if (req.path === '/api/migrate') return next(); // Gated by isInternalIp above — no API key required
       requireApiKey(req, res, next);
     });
 


### PR DESCRIPTION
## Summary

Found during a fresh-EC2 patient-zero dogfood on 2026-04-08. Three P0/P1 blockers prevent any new user from completing a first-time \`docker compose up\`, plus a bonus memory-DB SSL fix.

## The bugs

### Bug 1 — MongoDB index conflict kills operator subsystem (P0)

\`operator_audit_logs\` was defining two indexes on \`{ timestamp: 1 }\`:
- \`createIndex({ timestamp: 1 })\` — auto-named \`timestamp_1\`
- \`createIndex({ timestamp: 1 }, { name: 'ttl_90d', expireAfterSeconds: 90 * 86400 })\`

MongoDB rejects the second because same key + different name/options is not allowed. Symptom:

\`\`\`
[bootstrap:services] Operator subsystem initialization failed
(An equivalent index already exists with a different name and options...)
\`\`\`

**Fix:** drop the redundant plain index. The TTL index already serves timestamp sort queries — MongoDB uses a TTL index for \`sort({ timestamp: 1 })\` exactly the same as a plain ascending index.

### Bug 2 — Onboarding LLM provider doesn't fallback on empty string (P0)

\`services.ts\` used \`??\` which only falls back on \`null\`/\`undefined\`. When a user copies \`.env.example\` and leaves \`ONBOARDING_LLM_PROVIDER=\` blank, the env var becomes an empty string \`\"\"\`, which passes through \`??\` and hits:

\`\`\`
[bootstrap:services] Onboarding service initialization failed
(Unknown LLM provider: )
\`\`\`

**Fix:** \`process.env.ONBOARDING_LLM_PROVIDER?.trim() || process.env.LLM_PROVIDER?.trim() || 'anthropic'\`. Same pattern for \`ONBOARDING_MODEL\`.

**Also:** audit \`.env.example\` — Docker Compose's \`env_file\` parser does NOT support inline \`# comment\` after \`=\`. Any line matching \`VAR=<value>   # comment\` becomes \`VAR=<value>   # comment\` (comment included in value). Moved every inline comment to its own line above the key. Added a warning note at the top of the file.

### Bug 3 — \`/api/migrate\` returns 401 to the compose sidecar (P1)

The \`migrate\` one-shot in \`docker-compose.yml\` hits \`POST /api/migrate\` from the \`curlimages/curl\` sidecar without any credentials. The route was behind the \`x-api-key\` middleware. Patient zero doesn't have an API key yet (they're running schema migration *before* bootstrap), so the migrate container exited with \`curl: (22) The requested URL returned error: 401\`.

**Fix:**
- Exempt \`/api/migrate\` from the \`requireApiKey\` middleware.
- Add an \`isInternalIp()\` gate that accepts loopback + RFC1918 (\`10/8\`, \`192.168/16\`, \`172.16/12\`) + IPv6 ULA (\`fc00::/7\`) + link-local (\`169.254/16\`). Docker compose bridge (172.16/12 by default) passes; the public internet does not.
- Set \`app.set('trust proxy', 'loopback, linklocal, uniquelocal')\` so \`req.ip\` reflects the real client when the API runs behind a reverse proxy (ALB, compose sidecar).
- Log rejected calls with the observed IP so misconfiguration is debuggable.

This is option A from the patient-zero spec. Didn't pick option B (pass \`YCLAW_SETUP_TOKEN\`) because \`/api/migrate\` runs *before* the root operator exists, and the setup token has a different purpose (operator bootstrap). Didn't pick option C (inline in startup) because the current separation — API healthy → one-shot migrate — is useful for debugging migrations without a full restart.

### Bonus — \`Memory database unavailable (The server does not support SSL connections)\`

\`bootstrap/services.ts\` was:
1. Stripping \`?sslmode=\` from \`MEMORY_DATABASE_URL\` (line 250, removed)
2. Hardcoding \`ssl: { rejectUnauthorized: false }\` — force-SSL on every connection

This broke against the bundled \`postgres:16-alpine\` container, which doesn't speak SSL. Adding \`?sslmode=disable\` to the URL didn't help because the code stripped it out before handing it to \`pg\`.

**Fix:**
- Don't strip \`sslmode\` from the URL.
- Parse \`sslmode=disable\` and pass \`ssl: false\` when present.
- Otherwise default to \`ssl: { rejectUnauthorized: false }\` (unchanged — still needed for RDS/Neon with self-signed certs).
- Default the compose \`MEMORY_DATABASE_URL\` to \`?sslmode=disable\` so the bundled container works out of the box.
- Update \`.env.example\` MEMORY_DATABASE_URL to match.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm run typecheck\` — clean (core + cli + memory)
- [x] \`npm run lint\` — clean (only pre-existing mission-control warning, not touched here)
- [x] \`npm test\` — **1806/1806 passing** across 111 test files
- [ ] Manual verification on a fresh host (per the patient-zero spec):
  - \`docker compose down -v && docker compose up -d --build\`
  - \`docker compose logs migrate\` → exit 0, no 401
  - \`docker compose logs api | grep -i operator\` → \"indexes ensured\", NOT \"subsystem failed\"
  - \`docker compose logs api | grep -i onboarding\` → \"initialized\", NOT \"failed\"
  - \`docker compose logs api | grep -i memory\` → \"connected\", NOT \"unavailable\"

## Files changed

- \`packages/core/src/operators/audit-logger.ts\` — drop duplicate timestamp index
- \`packages/core/src/bootstrap/services.ts\` — onboarding env fallback + sslmode respect
- \`packages/core/src/triggers/webhook.ts\` — /api/migrate internal-IP gate + trust proxy
- \`docker-compose.yml\` — default MEMORY_DATABASE_URL to sslmode=disable
- \`.env.example\` — move ALL inline comments to line-above form + mirror compose URL

## Follow-ups not in this PR

- Consider adding an integration test that boots the full compose stack and asserts \`docker compose logs migrate\` exits 0 (would have caught all three bugs before shipping).
- The Mission Control pre-existing lint warning on \`src/app/operators/activity/client.tsx:50\` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)