### PR TITLE
feat: discord integration — executor, event handler, agent wiring

### DIFF
--- a/departments/marketing/ember.yaml
+++ b/departments/marketing/ember.yaml
@@ -50,6 +50,9 @@ triggers:
   - type: event
     event: reviewer:flagged
     task: revise_flagged_content
+  - type: event
+    event: discord:message
+    task: monitor_discord_sentiment
 
   - type: event
     event: claudeception:reflect
@@ -80,6 +83,7 @@ actions:
   - telegram:announce
   - slack:message
   - slack:thread_reply
+  - discord:get_channel_history
   - event:publish
 
 data_sources: []
@@ -90,6 +94,7 @@ event_subscriptions:
   - forge:asset_ready
   - reviewer:approved
   - reviewer:flagged
+  - discord:message
 
 event_publications:
   - standup:report

--- a/departments/marketing/scout.yaml
+++ b/departments/marketing/scout.yaml
@@ -43,6 +43,9 @@ triggers:
     event: strategist:scout_directive
     task: handle_directive
   - type: event
+    event: discord:message
+    task: monitor_discord_intel
+  - type: event
     event: claudeception:reflect
     task: self_reflection
     model:
@@ -62,6 +65,7 @@ actions:
   - email:send
   - slack:message
   - slack:thread_reply
+  - discord:get_channel_history
   - event:publish
 
 data_sources: []
@@ -69,6 +73,7 @@ data_sources: []
 event_subscriptions:
   - strategist:scout_directive
   - claudeception:reflect
+  - discord:message
 
 event_publications:
   - standup:report

--- a/departments/operations/sentinel.yaml
+++ b/departments/operations/sentinel.yaml
@@ -37,6 +37,9 @@ triggers:
     event: deployer:deploy_complete
     task: post_deploy_verification
   - type: event
+    event: discord:mention
+    task: handle_discord_infra
+  - type: event
     event: strategist:sentinel_directive
     task: handle_directive
   - type: event
@@ -58,6 +61,12 @@ actions:
   - slack:message
   - slack:alert
   - slack:thread_reply
+  - discord:message
+  - discord:thread_reply
+  - discord:get_channel_history
+  - discord:get_thread
+  - discord:react
+  - discord:alert
   - event:publish
 
 data_sources: []
@@ -66,6 +75,7 @@ event_subscriptions:
   - strategist:sentinel_directive
   - claudeception:reflect
   - deployer:deploy_complete
+  - discord:mention
 
 event_publications:
   - standup:report

--- a/departments/support/guide.yaml
+++ b/departments/support/guide.yaml
@@ -27,6 +27,9 @@ triggers:
     event: keeper:support_case
     task: handle_support
   - type: event
+    event: discord:mention
+    task: handle_discord_support
+  - type: event
     event: strategist:guide_directive
     task: handle_directive
   - type: event
@@ -47,6 +50,9 @@ actions:
   - vault:search
   - slack:message
   - slack:thread_reply
+  - discord:thread_reply
+  - discord:get_thread
+  - discord:react
   - event:publish
 
 data_sources: []
@@ -55,6 +61,7 @@ event_subscriptions:
   - strategist:guide_directive
   - claudeception:reflect
   - keeper:support_case
+  - discord:mention
 
 event_publications:
   - standup:report

--- a/departments/support/keeper.yaml
+++ b/departments/support/keeper.yaml
@@ -24,6 +24,12 @@ triggers:
     event: telegram:message
     task: handle_message
   - type: event
+    event: discord:message
+    task: handle_discord_message
+  - type: event
+    event: discord:mention
+    task: handle_discord_message
+  - type: event
     event: strategist:keeper_directive
     task: handle_directive
   - type: event
@@ -58,6 +64,12 @@ actions:
   - telegram:set_permissions
   - slack:message
   - slack:alert
+  - discord:message
+  - discord:thread_reply
+  - discord:create_thread
+  - discord:get_channel_history
+  - discord:get_thread
+  - discord:react
   - event:publish
 
 data_sources: []
@@ -65,6 +77,8 @@ data_sources: []
 event_subscriptions:
   - claudeception:reflect
   - telegram:message
+  - discord:message
+  - discord:mention
   - strategist:keeper_directive
 
 event_publications:

--- a/packages/core/src/actions/discord.ts
+++ b/packages/core/src/actions/discord.ts
@@ -1,0 +1,621 @@
+import { createHash } from 'node:crypto';
+import type { Redis } from 'ioredis';
+import type { ActionResult, ActionExecutor } from './types.js';
+import type { ToolDefinition } from '../config/schema.js';
+import type { DiscordChannelAdapter } from '../adapters/channels/DiscordChannelAdapter.js';
+import { createLogger } from '../logging/logger.js';
+
+const logger = createLogger('discord-executor');
+
+// ─── Discord Action Executor ────────────────────────────────────────────────
+//
+// Actions:
+//   discord:message            - Post a message to a channel
+//   discord:thread_reply       - Reply in a thread
+//   discord:create_thread      - Start a thread on a message
+//   discord:get_channel_history - Get recent messages from a channel
+//   discord:get_thread         - Get all replies in a thread
+//   discord:react              - Add a reaction to a message
+//   discord:alert              - Post a message with alert formatting
+//
+// Required env vars:
+//   DISCORD_BOT_TOKEN — Discord bot token (read by DiscordChannelAdapter)
+//
+// Guardrails (all MUST be enforced):
+//   - 90s per-channel cooldown per agent, 30s per-thread cooldown per agent
+//   - 20 messages/hour/agent global cap
+//   - 600 char max on public-channel messages (threads exempt)
+//   - Dedup fingerprinting (1h window, copied from SlackExecutor)
+//   - No DMs — any user-targeted action is rejected
+//   - Channel resolution: symbolic names in DISCORD_CHANNELS or raw snowflakes
+//
+// The executor does NOT own the Discord client. It wraps a shared
+// DiscordChannelAdapter (created by InfrastructureFactory) so the same
+// gateway connection is reused for outbound notifications (ChannelNotifier),
+// agent tool calls (this executor), and inbound event handling
+// (DiscordEventHandler).
+//
+
+// ─── Channel Map ────────────────────────────────────────────────────────────
+// Placeholder snowflake IDs. Operators must replace these with real channel
+// IDs after creating the server structure (see docs/discord-integration.md
+// when that file lands, and the post-implementation operator checklist).
+
+export const DISCORD_CHANNELS = {
+  general: 'PLACEHOLDER_GENERAL_ID',
+  support: 'PLACEHOLDER_SUPPORT_ID',
+  development: 'PLACEHOLDER_DEVELOPMENT_ID',
+  marketing: 'PLACEHOLDER_MARKETING_ID',
+  agent_observations: 'PLACEHOLDER_OBSERVATIONS_ID',
+  agent_escalations: 'PLACEHOLDER_ESCALATIONS_ID',
+  agent_review_queue: 'PLACEHOLDER_REVIEW_QUEUE_ID',
+  agent_audit_log: 'PLACEHOLDER_AUDIT_LOG_ID',
+} as const;
+
+export type DiscordChannelName = keyof typeof DISCORD_CHANNELS;
+
+// ─── Agent Identity Map ─────────────────────────────────────────────────────
+
+export const DISCORD_AGENT_IDENTITIES: Record<string, {
+  displayName: string;
+  avatarUrl: string;
+  department: string;
+  color: string;
+}> = {
+  keeper:    { displayName: 'Keeper [AI]',    avatarUrl: '', department: 'support',    color: '#3B82F6' },
+  guide:     { displayName: 'Guide [AI]',     avatarUrl: '', department: 'support',    color: '#0EA5E9' },
+  sentinel:  { displayName: 'Sentinel [AI]',  avatarUrl: '', department: 'operations', color: '#EF4444' },
+  ember:     { displayName: 'Ember [AI]',     avatarUrl: '', department: 'marketing',  color: '#F97316' },
+  scout:     { displayName: 'Scout [AI]',     avatarUrl: '', department: 'marketing',  color: '#14B8A6' },
+};
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const DEFAULT_HISTORY_LIMIT = 50;
+const MAX_HISTORY_LIMIT = 100;
+
+const PUBLIC_MESSAGE_MAX_LEN = 600;
+
+/** Per-agent, per-channel cooldown for top-level messages (seconds). */
+const CHANNEL_COOLDOWN_S = 90;
+/** Per-agent, per-thread cooldown for thread replies (seconds). */
+const THREAD_COOLDOWN_S = 30;
+/** Global per-agent hourly cap. */
+const HOURLY_CAP = 20;
+/** Dedup window (seconds). */
+const DEDUP_TTL_S = 3600;
+
+const DEDUP_PREFIX = 'discord:dedup:';
+const COOLDOWN_PREFIX = 'discord:cooldown:';
+const COOLDOWN_THREAD_PREFIX = 'discord:cooldown:thread:';
+const HOURLY_PREFIX = 'discord:hourly:';
+
+// ─── Executor ───────────────────────────────────────────────────────────────
+
+export class DiscordExecutor implements ActionExecutor {
+  readonly name = 'discord';
+  private readonly adapter: DiscordChannelAdapter;
+  private readonly redis: Redis | null;
+
+  constructor(adapter: DiscordChannelAdapter, redis?: Redis | null) {
+    this.adapter = adapter;
+    this.redis = redis ?? null;
+
+    if (!process.env.DISCORD_BOT_TOKEN) {
+      logger.warn('DISCORD_BOT_TOKEN not configured; DiscordExecutor will be non-functional until the adapter connects.');
+    }
+    logger.info('DiscordExecutor initialized', { redisEnabled: !!this.redis });
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return this.adapter.healthy();
+  }
+
+  // ─── Tool Definitions ───────────────────────────────────────────────────
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'discord:message',
+        description: 'Post a message to a Discord channel (max 600 chars). Use a thread for longer replies.',
+        parameters: {
+          channel: { type: 'string', description: 'Channel name from DISCORD_CHANNELS (e.g. "support") or raw snowflake ID', required: true },
+          text: { type: 'string', description: 'Message content (max 600 characters in public channels)', required: true },
+          replyToMessageId: { type: 'string', description: 'Optional message ID to reply to' },
+          agentName: { type: 'string', description: 'Agent identity key for display name override (e.g. "keeper")' },
+        },
+      },
+      {
+        name: 'discord:thread_reply',
+        description: 'Reply inside an existing Discord thread. Character limit is the Discord native 2000 char limit.',
+        parameters: {
+          channel: { type: 'string', description: 'Channel containing the thread (symbolic name or snowflake)', required: true },
+          threadId: { type: 'string', description: 'Thread ID (Discord threads are sub-channels with their own IDs)', required: true },
+          text: { type: 'string', description: 'Reply content', required: true },
+          agentName: { type: 'string', description: 'Agent identity key' },
+        },
+      },
+      {
+        name: 'discord:create_thread',
+        description: 'Create a new thread anchored on a message in a Discord channel.',
+        parameters: {
+          channel: { type: 'string', description: 'Channel containing the anchor message', required: true },
+          messageId: { type: 'string', description: 'Message ID to start the thread from', required: true },
+          name: { type: 'string', description: 'Thread name', required: true },
+        },
+      },
+      {
+        name: 'discord:get_channel_history',
+        description: 'Fetch recent messages from a Discord channel (read-only).',
+        parameters: {
+          channel: { type: 'string', description: 'Channel name or snowflake', required: true },
+          limit: { type: 'number', description: 'Max messages to fetch (default 50, max 100)' },
+        },
+      },
+      {
+        name: 'discord:get_thread',
+        description: 'Fetch messages from a Discord thread (read-only).',
+        parameters: {
+          threadId: { type: 'string', description: 'Thread ID', required: true },
+          limit: { type: 'number', description: 'Max messages to fetch (default 50, max 100)' },
+        },
+      },
+      {
+        name: 'discord:react',
+        description: 'Add an emoji reaction to a Discord message.',
+        parameters: {
+          channel: { type: 'string', description: 'Channel containing the message', required: true },
+          messageId: { type: 'string', description: 'Message ID to react to', required: true },
+          emoji: { type: 'string', description: 'Unicode emoji or custom emoji string (e.g. "👍" or "custom_name:12345")', required: true },
+        },
+      },
+      {
+        name: 'discord:alert',
+        description: 'Post an alert message (colored embed) to a Discord channel. Bypasses the 600-char public limit since alerts use an embed body.',
+        parameters: {
+          channel: { type: 'string', description: 'Channel name or snowflake', required: true },
+          text: { type: 'string', description: 'Alert body text', required: true },
+          severity: { type: 'string', description: 'Severity: info | warning | error | critical | success (default: warning)' },
+          title: { type: 'string', description: 'Optional alert title' },
+          agentName: { type: 'string', description: 'Agent identity key' },
+        },
+      },
+    ];
+  }
+
+  // ─── Defaults for parameter injection ─────────────────────────────────────
+
+  static readonly DEFAULTS: Record<string, Record<string, unknown>> = {
+    'discord:get_channel_history': { limit: DEFAULT_HISTORY_LIMIT },
+    'discord:get_thread': { limit: DEFAULT_HISTORY_LIMIT },
+  };
+
+  // ─── Dispatch ───────────────────────────────────────────────────────────
+
+  async execute(action: string, params: Record<string, unknown>): Promise<ActionResult> {
+    // No DMs — reject anything that targets a user instead of a channel.
+    if (params.userId && !params.channel) {
+      return { success: false, error: 'Discord DMs are not supported. Use a channel or thread.' };
+    }
+
+    switch (action) {
+      case 'message':
+        return this.postMessage(params);
+      case 'thread_reply':
+        return this.threadReply(params);
+      case 'create_thread':
+        return this.createThread(params);
+      case 'get_channel_history':
+        return this.getChannelHistory(params);
+      case 'get_thread':
+        return this.getThread(params);
+      case 'react':
+        return this.react(params);
+      case 'alert':
+        return this.postAlert(params);
+      default:
+        return { success: false, error: `Unknown Discord action: ${action}` };
+    }
+  }
+
+  // ─── Channel Resolution ─────────────────────────────────────────────────
+
+  /**
+   * Accept a symbolic channel name from DISCORD_CHANNELS or a raw snowflake
+   * ID. Returns the resolved ID or throws if the name isn't known.
+   */
+  resolveChannelId(input: string): string {
+    const trimmed = input.trim();
+    if (trimmed in DISCORD_CHANNELS) {
+      return DISCORD_CHANNELS[trimmed as DiscordChannelName];
+    }
+    // Discord snowflakes are 17–20 digits
+    if (/^\d{17,20}$/.test(trimmed)) return trimmed;
+    throw new Error(`Unknown Discord channel: "${input}". Use a name from DISCORD_CHANNELS or a snowflake ID.`);
+  }
+
+  // ─── Dedup ──────────────────────────────────────────────────────────────
+
+  /**
+   * Semantic fingerprint of a (channel, text) pair. Normalizes volatile
+   * substrings (UUIDs, timestamps, task ids, commit SHAs) so that
+   * semantically identical messages collapse to the same key. Copied from
+   * SlackExecutor.fingerprint and extended with discord-specific patterns
+   * (Discord snowflakes).
+   */
+  fingerprint(channel: string, text: string): string {
+    const normalized = text
+      .toLowerCase()
+      .replace(/dep-\d+-[a-z0-9]+/g, 'dep-ID')
+      .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g, 'UUID')
+      .replace(/\d{4}-\d{2}-\d{2}[tT ]\d{2}:\d{2}[:\d.]*/g, 'TIMESTAMP')
+      .replace(/`[a-f0-9]{7,12}`/g, '`COMMIT`')
+      .replace(/\d{2}:\d{2}(:\d{2})?(\.\d+)?/g, 'TIME')
+      .replace(/\d+ (task|minute|hour|day|pr|issue)/g, 'N $1')
+      // Discord snowflakes
+      .replace(/\b\d{17,20}\b/g, 'SNOWFLAKE')
+      .trim();
+
+    return createHash('sha256').update(`${channel}:${normalized}`).digest('hex').slice(0, 32);
+  }
+
+  async isDuplicate(channelId: string, text: string): Promise<boolean> {
+    if (!this.redis) return false;
+    const fp = this.fingerprint(channelId, text);
+    const key = `${DEDUP_PREFIX}${fp}`;
+    try {
+      const result = await this.redis.set(key, Date.now().toString(), 'EX', DEDUP_TTL_S, 'NX');
+      return result === null;
+    } catch (err) {
+      logger.warn('Discord dedup check failed, allowing message', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false; // fail-open
+    }
+  }
+
+  // ─── Rate Limiting ──────────────────────────────────────────────────────
+
+  private hourBucket(): string {
+    const d = new Date();
+    return `${d.getUTCFullYear()}-${d.getUTCMonth() + 1}-${d.getUTCDate()}-${d.getUTCHours()}`;
+  }
+
+  /**
+   * Check all three rate limits for a top-level channel post. Returns null
+   * on pass, or a string reason on rejection. Fails open if Redis is down.
+   */
+  private async checkChannelRateLimits(agentName: string, channelId: string): Promise<string | null> {
+    if (!this.redis) return null;
+    try {
+      // Global hourly cap
+      const hourKey = `${HOURLY_PREFIX}${agentName}:${this.hourBucket()}`;
+      const hourCount = parseInt((await this.redis.get(hourKey)) ?? '0', 10);
+      if (hourCount >= HOURLY_CAP) {
+        return `global hourly cap of ${HOURLY_CAP} msgs reached for ${agentName}`;
+      }
+
+      // Per-channel cooldown
+      const cooldownKey = `${COOLDOWN_PREFIX}${agentName}:${channelId}`;
+      const cooldownResult = await this.redis.set(cooldownKey, '1', 'EX', CHANNEL_COOLDOWN_S, 'NX');
+      if (cooldownResult === null) {
+        return `channel cooldown active (${CHANNEL_COOLDOWN_S}s) for ${agentName} in ${channelId}`;
+      }
+
+      // Increment hourly count; set expiry on first increment
+      await this.redis.incr(hourKey);
+      await this.redis.expire(hourKey, 3600);
+      return null;
+    } catch (err) {
+      logger.warn('Discord rate-limit check failed, allowing message (fail-open)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Check thread reply rate limits (thread cooldown + hourly cap).
+   */
+  private async checkThreadRateLimits(agentName: string, threadId: string): Promise<string | null> {
+    if (!this.redis) return null;
+    try {
+      const hourKey = `${HOURLY_PREFIX}${agentName}:${this.hourBucket()}`;
+      const hourCount = parseInt((await this.redis.get(hourKey)) ?? '0', 10);
+      if (hourCount >= HOURLY_CAP) {
+        return `global hourly cap of ${HOURLY_CAP} msgs reached for ${agentName}`;
+      }
+
+      const cooldownKey = `${COOLDOWN_THREAD_PREFIX}${agentName}:${threadId}`;
+      const cooldownResult = await this.redis.set(cooldownKey, '1', 'EX', THREAD_COOLDOWN_S, 'NX');
+      if (cooldownResult === null) {
+        return `thread cooldown active (${THREAD_COOLDOWN_S}s) for ${agentName} in ${threadId}`;
+      }
+
+      await this.redis.incr(hourKey);
+      await this.redis.expire(hourKey, 3600);
+      return null;
+    } catch (err) {
+      logger.warn('Discord thread rate-limit check failed, allowing message (fail-open)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  // ─── Actions ────────────────────────────────────────────────────────────
+
+  private async postMessage(params: Record<string, unknown>): Promise<ActionResult> {
+    const channelInput = params.channel as string | undefined;
+    const text = params.text as string | undefined;
+    const replyToMessageId = params.replyToMessageId as string | undefined;
+    const agentName = (params.agentName as string | undefined) ?? 'system';
+
+    if (!channelInput || !text) {
+      return { success: false, error: 'Missing required parameters: channel, text' };
+    }
+
+    if (text.length > PUBLIC_MESSAGE_MAX_LEN) {
+      return { success: false, error: `Message exceeds ${PUBLIC_MESSAGE_MAX_LEN} character limit for public channels. Use a thread for longer content.` };
+    }
+
+    let channelId: string;
+    try {
+      channelId = this.resolveChannelId(channelInput);
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    if (await this.isDuplicate(channelId, text)) {
+      logger.info('Discord message suppressed (duplicate)', { channelId, agentName });
+      return { success: true, data: { suppressed: true, reason: 'duplicate_within_window' } };
+    }
+
+    const rateLimitReason = await this.checkChannelRateLimits(agentName, channelId);
+    if (rateLimitReason) {
+      logger.info('Discord message suppressed (rate limited)', { channelId, agentName, reason: rateLimitReason });
+      return { success: true, data: { suppressed: true, reason: 'rate_limited', detail: rateLimitReason } };
+    }
+
+    const identity = DISCORD_AGENT_IDENTITIES[agentName];
+    logger.info('Posting Discord message', {
+      channelId, agentName, textLength: text.length,
+    });
+
+    const result = await this.adapter.send(
+      { channelId },
+      {
+        text,
+        ...(replyToMessageId ? { replyTo: { messageId: replyToMessageId, channelId } } : {}),
+        ...(identity
+          ? { identity: { displayName: identity.displayName, avatarUrl: identity.avatarUrl || undefined } as { displayName?: string; avatarUrl?: string } }
+          : {}),
+      },
+    );
+
+    if (!result.success) {
+      logger.error('Failed to post Discord message', { channelId, error: result.error });
+      return { success: false, error: `Failed to post message: ${result.error ?? 'unknown error'}` };
+    }
+    return {
+      success: true,
+      data: { messageId: result.messageId, channelId, agentName },
+    };
+  }
+
+  private async threadReply(params: Record<string, unknown>): Promise<ActionResult> {
+    const channelInput = params.channel as string | undefined;
+    const threadId = params.threadId as string | undefined;
+    const text = params.text as string | undefined;
+    const agentName = (params.agentName as string | undefined) ?? 'system';
+
+    if (!channelInput || !threadId || !text) {
+      return { success: false, error: 'Missing required parameters: channel, threadId, text' };
+    }
+
+    let channelId: string;
+    try {
+      channelId = this.resolveChannelId(channelInput);
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    // Thread replies allow longer text (Discord caps at 2000 natively)
+    if (await this.isDuplicate(threadId, text)) {
+      return { success: true, data: { suppressed: true, reason: 'duplicate_within_window' } };
+    }
+
+    const rateLimitReason = await this.checkThreadRateLimits(agentName, threadId);
+    if (rateLimitReason) {
+      logger.info('Discord thread reply suppressed (rate limited)', { threadId, agentName, reason: rateLimitReason });
+      return { success: true, data: { suppressed: true, reason: 'rate_limited', detail: rateLimitReason } };
+    }
+
+    logger.info('Posting Discord thread reply', {
+      channelId, threadId, agentName, textLength: text.length,
+    });
+
+    const result = await this.adapter.send(
+      { channelId, threadId },
+      { text, threadId },
+    );
+
+    if (!result.success) {
+      return { success: false, error: `Failed to post thread reply: ${result.error ?? 'unknown error'}` };
+    }
+    return {
+      success: true,
+      data: { messageId: result.messageId, channelId, threadId, agentName },
+    };
+  }
+
+  private async createThread(params: Record<string, unknown>): Promise<ActionResult> {
+    const channelInput = params.channel as string | undefined;
+    const messageId = params.messageId as string | undefined;
+    const name = params.name as string | undefined;
+
+    if (!channelInput || !messageId || !name) {
+      return { success: false, error: 'Missing required parameters: channel, messageId, name' };
+    }
+
+    let channelId: string;
+    try {
+      channelId = this.resolveChannelId(channelInput);
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    try {
+      if (typeof this.adapter.createThread !== 'function') {
+        return { success: false, error: 'Discord adapter does not implement createThread' };
+      }
+      const thread = await this.adapter.createThread({ messageId, channelId }, name);
+      return {
+        success: true,
+        data: { threadId: thread.threadId, channelId: thread.channelId, name },
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('Failed to create Discord thread', { channelId, messageId, error: msg });
+      return { success: false, error: `Failed to create thread: ${msg}` };
+    }
+  }
+
+  private async getChannelHistory(params: Record<string, unknown>): Promise<ActionResult> {
+    const channelInput = params.channel as string | undefined;
+    const limit = typeof params.limit === 'number'
+      ? Math.min(Math.max(params.limit, 1), MAX_HISTORY_LIMIT)
+      : DEFAULT_HISTORY_LIMIT;
+
+    if (!channelInput) {
+      return { success: false, error: 'Missing required parameter: channel' };
+    }
+
+    let channelId: string;
+    try {
+      channelId = this.resolveChannelId(channelInput);
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    try {
+      const messages = await this.adapter.fetchChannelHistory(channelId, limit);
+      return { success: true, data: { channel: channelInput, channelId, messages } };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('Failed to fetch Discord channel history', { channelId, error: msg });
+      return { success: false, error: `Failed to fetch channel history: ${msg}` };
+    }
+  }
+
+  private async getThread(params: Record<string, unknown>): Promise<ActionResult> {
+    const threadId = params.threadId as string | undefined;
+    const limit = typeof params.limit === 'number'
+      ? Math.min(Math.max(params.limit, 1), MAX_HISTORY_LIMIT)
+      : DEFAULT_HISTORY_LIMIT;
+
+    if (!threadId) {
+      return { success: false, error: 'Missing required parameter: threadId' };
+    }
+
+    try {
+      const messages = await this.adapter.fetchThreadReplies(threadId, limit);
+      return { success: true, data: { threadId, messages } };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('Failed to fetch Discord thread replies', { threadId, error: msg });
+      return { success: false, error: `Failed to fetch thread: ${msg}` };
+    }
+  }
+
+  private async react(params: Record<string, unknown>): Promise<ActionResult> {
+    const channelInput = params.channel as string | undefined;
+    const messageId = params.messageId as string | undefined;
+    const emoji = params.emoji as string | undefined;
+
+    if (!channelInput || !messageId || !emoji) {
+      return { success: false, error: 'Missing required parameters: channel, messageId, emoji' };
+    }
+
+    let channelId: string;
+    try {
+      channelId = this.resolveChannelId(channelInput);
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    try {
+      if (typeof this.adapter.react !== 'function') {
+        return { success: false, error: 'Discord adapter does not implement react' };
+      }
+      await this.adapter.react({ messageId, channelId }, emoji);
+      return { success: true, data: { channelId, messageId, emoji } };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('Failed to add Discord reaction', { channelId, messageId, error: msg });
+      return { success: false, error: `Failed to react: ${msg}` };
+    }
+  }
+
+  private async postAlert(params: Record<string, unknown>): Promise<ActionResult> {
+    const channelInput = params.channel as string | undefined;
+    const text = params.text as string | undefined;
+    const severity = (params.severity as string | undefined) ?? 'warning';
+    const title = params.title as string | undefined;
+    const agentName = (params.agentName as string | undefined) ?? 'system';
+
+    if (!channelInput || !text) {
+      return { success: false, error: 'Missing required parameters: channel, text' };
+    }
+
+    let channelId: string;
+    try {
+      channelId = this.resolveChannelId(channelInput);
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    if (await this.isDuplicate(channelId, text)) {
+      return { success: true, data: { suppressed: true, reason: 'duplicate_within_window' } };
+    }
+
+    const rateLimitReason = await this.checkChannelRateLimits(agentName, channelId);
+    if (rateLimitReason) {
+      return { success: true, data: { suppressed: true, reason: 'rate_limited', detail: rateLimitReason } };
+    }
+
+    // Render the embed as plain markdown for the IChannel.send() call. The
+    // adapter doesn't expose embeds in the IChannel contract, so we pack the
+    // severity + title into a formatted text block. This keeps alerts
+    // distinctive without widening the interface.
+    const severityEmoji: Record<string, string> = {
+      info: 'ℹ️',
+      warning: '⚠️',
+      error: '❌',
+      critical: '🚨',
+      success: '✅',
+    };
+    const emoji = severityEmoji[severity] ?? '⚠️';
+    const header = `${emoji} **${(title ?? `${severity.toUpperCase()} alert`)}**`;
+    const formatted = `${header}\n${text}`;
+
+    const identity = DISCORD_AGENT_IDENTITIES[agentName];
+    const result = await this.adapter.send(
+      { channelId },
+      {
+        text: formatted,
+        ...(identity
+          ? { identity: { displayName: identity.displayName, avatarUrl: identity.avatarUrl || undefined } as { displayName?: string; avatarUrl?: string } }
+          : {}),
+      },
+    );
+
+    if (!result.success) {
+      return { success: false, error: `Failed to post alert: ${result.error ?? 'unknown error'}` };
+    }
+    return {
+      success: true,
+      data: { messageId: result.messageId, channelId, severity, agentName },
+    };
+  }
+}

--- a/packages/core/src/actions/discord.ts
+++ b/packages/core/src/actions/discord.ts
@@ -82,6 +82,7 @@ const CHANNEL_COOLDOWN_S = 90;
 const THREAD_COOLDOWN_S = 30;
 /** Global per-agent hourly cap. */
 const HOURLY_CAP = 20;
+const HOURLY_WINDOW_S = 3600;
 /** Dedup window (seconds). */
 const DEDUP_TTL_S = 3600;
 
@@ -286,57 +287,82 @@ export class DiscordExecutor implements ActionExecutor {
    * on pass, or a string reason on rejection. Fails open if Redis is down.
    */
   private async checkChannelRateLimits(agentName: string, channelId: string): Promise<string | null> {
-    if (!this.redis) return null;
-    try {
-      // Global hourly cap
-      const hourKey = `${HOURLY_PREFIX}${agentName}:${this.hourBucket()}`;
-      const hourCount = parseInt((await this.redis.get(hourKey)) ?? '0', 10);
-      if (hourCount >= HOURLY_CAP) {
-        return `global hourly cap of ${HOURLY_CAP} msgs reached for ${agentName}`;
-      }
-
-      // Per-channel cooldown
-      const cooldownKey = `${COOLDOWN_PREFIX}${agentName}:${channelId}`;
-      const cooldownResult = await this.redis.set(cooldownKey, '1', 'EX', CHANNEL_COOLDOWN_S, 'NX');
-      if (cooldownResult === null) {
-        return `channel cooldown active (${CHANNEL_COOLDOWN_S}s) for ${agentName} in ${channelId}`;
-      }
-
-      // Increment hourly count; set expiry on first increment
-      await this.redis.incr(hourKey);
-      await this.redis.expire(hourKey, 3600);
-      return null;
-    } catch (err) {
-      logger.warn('Discord rate-limit check failed, allowing message (fail-open)', {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return null;
-    }
+    return this.checkRateLimits(
+      agentName,
+      `${COOLDOWN_PREFIX}${agentName}:${channelId}`,
+      CHANNEL_COOLDOWN_S,
+      `channel cooldown active (${CHANNEL_COOLDOWN_S}s) for ${agentName} in ${channelId}`,
+      'Discord rate-limit check failed, allowing message (fail-open)',
+    );
   }
 
   /**
    * Check thread reply rate limits (thread cooldown + hourly cap).
    */
   private async checkThreadRateLimits(agentName: string, threadId: string): Promise<string | null> {
+    return this.checkRateLimits(
+      agentName,
+      `${COOLDOWN_THREAD_PREFIX}${agentName}:${threadId}`,
+      THREAD_COOLDOWN_S,
+      `thread cooldown active (${THREAD_COOLDOWN_S}s) for ${agentName} in ${threadId}`,
+      'Discord thread rate-limit check failed, allowing message (fail-open)',
+    );
+  }
+
+  private async checkRateLimits(
+    agentName: string,
+    cooldownKey: string,
+    cooldownSeconds: number,
+    cooldownMessage: string,
+    failureLogMessage: string,
+  ): Promise<string | null> {
     if (!this.redis) return null;
+
+    const hourKey = `${HOURLY_PREFIX}${agentName}:${this.hourBucket()}`;
+
     try {
-      const hourKey = `${HOURLY_PREFIX}${agentName}:${this.hourBucket()}`;
-      const hourCount = parseInt((await this.redis.get(hourKey)) ?? '0', 10);
-      if (hourCount >= HOURLY_CAP) {
+      const result = await this.redis.eval(
+        `
+          local hourCount = tonumber(redis.call('GET', KEYS[1]) or '0')
+          if hourCount >= tonumber(ARGV[1]) then
+            return 'hourly_cap'
+          end
+
+          local cooldownSet = redis.call('SET', KEYS[2], '1', 'EX', ARGV[2], 'NX')
+          if not cooldownSet then
+            return 'cooldown'
+          end
+
+          local newHourCount = redis.call('INCR', KEYS[1])
+          if newHourCount == 1 then
+            redis.call('EXPIRE', KEYS[1], ARGV[3])
+          end
+
+          return 'ok'
+        `,
+        2,
+        hourKey,
+        cooldownKey,
+        HOURLY_CAP.toString(),
+        cooldownSeconds.toString(),
+        HOURLY_WINDOW_S.toString(),
+      );
+
+      if (result === 'ok') return null;
+      if (result === 'hourly_cap') {
         return `global hourly cap of ${HOURLY_CAP} msgs reached for ${agentName}`;
       }
-
-      const cooldownKey = `${COOLDOWN_THREAD_PREFIX}${agentName}:${threadId}`;
-      const cooldownResult = await this.redis.set(cooldownKey, '1', 'EX', THREAD_COOLDOWN_S, 'NX');
-      if (cooldownResult === null) {
-        return `thread cooldown active (${THREAD_COOLDOWN_S}s) for ${agentName} in ${threadId}`;
+      if (result === 'cooldown') {
+        return cooldownMessage;
       }
 
-      await this.redis.incr(hourKey);
-      await this.redis.expire(hourKey, 3600);
+      logger.warn('Discord rate-limit script returned unexpected result, allowing message (fail-open)', {
+        agentName,
+        result,
+      });
       return null;
     } catch (err) {
-      logger.warn('Discord thread rate-limit check failed, allowing message (fail-open)', {
+      logger.warn(failureLogMessage, {
         error: err instanceof Error ? err.message : String(err),
       });
       return null;

--- a/packages/core/src/adapters/channels/DiscordChannelAdapter.ts
+++ b/packages/core/src/adapters/channels/DiscordChannelAdapter.ts
@@ -130,11 +130,14 @@ export class DiscordChannelAdapter implements IChannel {
         const user = await this.client.users.fetch(target.userId);
         channel = await user.createDM();
       } else {
-        channel = await this.client.channels.fetch(target.channelId);
+        if (!target.channelId) {
+          return { success: false, error: 'No channelId or userId provided' };
+        }
+        channel = await this.requireNonDmChannel(target.channelId);
       }
 
       if (!channel) {
-        return { success: false, error: `Channel not found: ${target.channelId}` };
+        return { success: false, error: `Channel not found: ${target.channelId ?? '(none)'}` };
       }
 
       const sendOptions: any = { content: message.text };
@@ -206,7 +209,7 @@ export class DiscordChannelAdapter implements IChannel {
     if (!this.client || !this.connected) return;
 
     try {
-      const channel = await this.client.channels.fetch(target.channelId);
+      const channel = await this.requireNonDmChannel(target.channelId);
       const message = await channel.messages.fetch(target.messageId);
       await message.react(emoji);
     } catch (err) {
@@ -220,7 +223,7 @@ export class DiscordChannelAdapter implements IChannel {
       throw new Error('Discord adapter not connected');
     }
 
-    const channel = await this.client.channels.fetch(target.channelId);
+    const channel = await this.requireNonDmChannel(target.channelId);
     const message = await channel.messages.fetch(target.messageId);
     const thread = await message.startThread({ name: threadName });
 
@@ -261,7 +264,7 @@ export class DiscordChannelAdapter implements IChannel {
     if (!this.client || !this.connected) {
       throw new Error('Discord adapter not connected');
     }
-    const channel = await this.client.channels.fetch(channelId);
+    const channel = await this.requireNonDmChannel(channelId);
     if (!channel) throw new Error(`Channel not found: ${channelId}`);
     if (typeof channel.messages?.fetch !== 'function') {
       throw new Error(`Channel ${channelId} is not a text channel`);
@@ -309,5 +312,16 @@ export class DiscordChannelAdapter implements IChannel {
   /** Expose readiness flag for the executor's health check. */
   isConnected(): boolean {
     return this.connected;
+  }
+
+  private async requireNonDmChannel(channelId: string): Promise<any> {
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel) {
+      throw new Error(`Channel not found: ${channelId}`);
+    }
+    if (channel.isDMBased?.() === true) {
+      throw new Error(`Discord DMs are not supported: ${channelId}`);
+    }
+    return channel;
   }
 }

--- a/packages/core/src/adapters/channels/DiscordChannelAdapter.ts
+++ b/packages/core/src/adapters/channels/DiscordChannelAdapter.ts
@@ -241,4 +241,73 @@ export class DiscordChannelAdapter implements IChannel {
       error: result.error,
     };
   }
+
+  // ─── Additional helpers (not part of IChannel) ──────────────────────────
+  // Exposed for DiscordExecutor which needs history fetches beyond what the
+  // shared interface supports. Kept as named methods on the concrete adapter
+  // so we don't widen IChannel with Discord-specific affordances.
+
+  /**
+   * Fetch recent messages from a channel (or thread). Returns a plain array
+   * of normalized message objects. Throws on failure (caller handles).
+   */
+  async fetchChannelHistory(channelId: string, limit = 50): Promise<Array<{
+    id: string;
+    author: { id: string; username: string; bot: boolean };
+    content: string;
+    createdAt: string;
+    threadId: string | null;
+  }>> {
+    if (!this.client || !this.connected) {
+      throw new Error('Discord adapter not connected');
+    }
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel) throw new Error(`Channel not found: ${channelId}`);
+    if (typeof channel.messages?.fetch !== 'function') {
+      throw new Error(`Channel ${channelId} is not a text channel`);
+    }
+
+    const collection = await channel.messages.fetch({ limit: Math.min(Math.max(limit, 1), 100) });
+    const messages: Array<{
+      id: string;
+      author: { id: string; username: string; bot: boolean };
+      content: string;
+      createdAt: string;
+      threadId: string | null;
+    }> = [];
+    // discord.js returns a Collection; iterate with .values()
+    for (const msg of collection.values()) {
+      messages.push({
+        id: msg.id,
+        author: {
+          id: msg.author?.id ?? '',
+          username: msg.author?.username ?? '',
+          bot: msg.author?.bot === true,
+        },
+        content: msg.content ?? '',
+        createdAt: msg.createdAt?.toISOString?.() ?? new Date().toISOString(),
+        threadId: msg.thread?.id ?? null,
+      });
+    }
+    return messages;
+  }
+
+  /**
+   * Fetch messages from a thread by thread id. Threads are channels in
+   * Discord, so this delegates to fetchChannelHistory under the hood.
+   */
+  async fetchThreadReplies(threadId: string, limit = 50): Promise<Array<{
+    id: string;
+    author: { id: string; username: string; bot: boolean };
+    content: string;
+    createdAt: string;
+    threadId: string | null;
+  }>> {
+    return this.fetchChannelHistory(threadId, limit);
+  }
+
+  /** Expose readiness flag for the executor's health check. */
+  isConnected(): boolean {
+    return this.connected;
+  }
 }

--- a/packages/core/src/bootstrap/actions.ts
+++ b/packages/core/src/bootstrap/actions.ts
@@ -10,6 +10,8 @@ import { ActionRegistryImpl } from '../actions/registry.js';
 import { TwitterExecutor } from '../actions/twitter.js';
 import { TelegramExecutor } from '../actions/telegram.js';
 import { SlackExecutor } from '../actions/slack.js';
+import { DiscordExecutor } from '../actions/discord.js';
+import type { DiscordChannelAdapter } from '../adapters/channels/DiscordChannelAdapter.js';
 import { GitHubExecutor } from '../actions/github/index.js';
 import { EmailExecutor } from '../actions/email.js';
 import { EventActionExecutor } from '../actions/event.js';
@@ -77,6 +79,23 @@ export async function initActions(services: ServiceContext): Promise<ActionConte
   }
 
   actionRegistry.register('slack', new SlackExecutor(slackDedupRedis));
+
+  // ─── Discord Executor ────────────────────────────────────────────────
+  // Reuse the shared DiscordChannelAdapter created by InfrastructureFactory
+  // so we do not open a second Discord gateway connection. The adapter is
+  // auto-enabled when DISCORD_BOT_TOKEN is set; when the token is absent we
+  // skip registration entirely. Redis (if available) is shared with Slack
+  // for dedup and rate-limit state.
+  const discordAdapter = services.infrastructure?.channels.get('discord') as
+    | DiscordChannelAdapter
+    | undefined;
+  if (discordAdapter) {
+    actionRegistry.register('discord', new DiscordExecutor(discordAdapter, slackDedupRedis));
+    logger.info('Discord executor registered (sharing adapter from infrastructure.channels)');
+  } else {
+    logger.info('Discord executor skipped — no shared DiscordChannelAdapter (set DISCORD_BOT_TOKEN to enable)');
+  }
+
   actionRegistry.register('github', new GitHubExecutor());
   actionRegistry.register('email', new EmailExecutor());
   actionRegistry.register('event', new EventActionExecutor(eventBus));

--- a/packages/core/src/bootstrap/routes.ts
+++ b/packages/core/src/bootstrap/routes.ts
@@ -4,6 +4,8 @@ import { WebhookServer } from '../triggers/webhook.js';
 import { GitHubWebhookHandler } from '../triggers/github-webhook.js';
 import { TelegramWebhookHandler } from '../triggers/telegram-webhook.js';
 import { SlackWebhookHandler } from '../triggers/slack-webhook.js';
+import { DiscordEventHandler } from '../triggers/discord-event-handler.js';
+import type { DiscordChannelAdapter } from '../adapters/channels/DiscordChannelAdapter.js';
 import { CacheObserver } from '../logging/cache-observer.js';
 import { GitHubExecutor } from '../actions/github/index.js';
 import type { SlackExecutor } from '../actions/slack.js';
@@ -1009,6 +1011,26 @@ export async function initRoutes(
       }
     });
     logger.info('Slack webhook mounted at /slack/events');
+  }
+
+  // ─── Discord Event Handler ───────────────────────────────────────────
+  // Unlike Slack, Discord uses a persistent gateway connection (discord.js)
+  // rather than HTTP webhooks. The handler registers an in-process listener
+  // on the shared DiscordChannelAdapter — no Express route to mount.
+  //
+  // Guarded by DISCORD_BOT_TOKEN presence: if the token is unset the
+  // adapter is never created by InfrastructureFactory, so we skip wiring.
+  const discordAdapter = services.infrastructure?.channels.get('discord') as
+    | DiscordChannelAdapter
+    | undefined;
+  if (!process.env.DISCORD_BOT_TOKEN) {
+    logger.info('Discord event handler skipped — DISCORD_BOT_TOKEN not set');
+  } else if (!discordAdapter) {
+    logger.warn('Discord event handler skipped — DISCORD_BOT_TOKEN set but no adapter in infrastructure.channels');
+  } else {
+    const discordHandler = new DiscordEventHandler(eventBus, discordAdapter);
+    await discordHandler.start();
+    logger.info('Discord event handler started (inbound messages → EventBus)');
   }
 
   await webhookServer.start();

--- a/packages/core/src/triggers/discord-event-handler.ts
+++ b/packages/core/src/triggers/discord-event-handler.ts
@@ -7,6 +7,7 @@ const logger = createLogger('discord-event-handler');
 
 /** Max recent message IDs retained for dedup. */
 const MAX_EVENT_CACHE = 1000;
+const DISCORD_HANDLER_REGISTERED = '__yclawDiscordEventHandlerRegistered';
 
 // ─── Secret Redaction ──────────────────────────────────────────────────────
 // Match obvious token shapes and replace with [REDACTED] before publishing.
@@ -72,6 +73,15 @@ export class DiscordEventHandler {
 
   /** Register the inbound listener with the shared adapter. */
   async start(): Promise<void> {
+    const adapterWithRegistration = this.adapter as DiscordChannelAdapter & {
+      [DISCORD_HANDLER_REGISTERED]?: boolean;
+    };
+    if (adapterWithRegistration[DISCORD_HANDLER_REGISTERED]) {
+      logger.warn('DiscordEventHandler listener already registered on adapter; skipping duplicate start');
+      return;
+    }
+    adapterWithRegistration[DISCORD_HANDLER_REGISTERED] = true;
+
     await this.adapter.listen(async (inbound) => {
       try {
         await this.handleMessage(inbound);

--- a/packages/core/src/triggers/discord-event-handler.ts
+++ b/packages/core/src/triggers/discord-event-handler.ts
@@ -1,0 +1,183 @@
+import type { EventBus } from './event.js';
+import type { DiscordChannelAdapter } from '../adapters/channels/DiscordChannelAdapter.js';
+import type { InboundMessage } from '../interfaces/IChannel.js';
+import { createLogger } from '../logging/logger.js';
+
+const logger = createLogger('discord-event-handler');
+
+/** Max recent message IDs retained for dedup. */
+const MAX_EVENT_CACHE = 1000;
+
+// ─── Secret Redaction ──────────────────────────────────────────────────────
+// Match obvious token shapes and replace with [REDACTED] before publishing.
+// Keep patterns conservative — false positives on normal chat text are worse
+// than missing a clever leak (the inbound handler is defense-in-depth, not
+// a guarantee).
+
+/** Apply conservative secret-redaction patterns to message text. */
+function redact(text: string): string {
+  return text
+    // OpenAI keys (`sk-...`)
+    .replace(/sk-[a-zA-Z0-9_-]{20,}/g, '[REDACTED]')
+    // GitHub tokens (ghp_, gho_, ghu_, ghs_, ghr_)
+    .replace(/gh[psour]_[a-zA-Z0-9]{36,}/g, '[REDACTED]')
+    .replace(/github_pat_[a-zA-Z0-9_]{20,}/g, '[REDACTED]')
+    // AWS access keys
+    .replace(/AKIA[A-Z0-9]{16}/g, '[REDACTED]')
+    // Discord bot tokens (Mxxx.xxx.xxx and Nxxx.xxx.xxx)
+    .replace(/[MN][A-Za-z\d]{23,}\.[\w-]{6,}\.[\w-]{27,}/g, '[REDACTED]')
+    // Generic high-entropy bearer-shaped tokens (40+ chars, mixed case + digits)
+    .replace(/\b[a-zA-Z0-9_-]{40,}\b/g, (match) => {
+      const hasLower = /[a-z]/.test(match);
+      const hasUpper = /[A-Z]/.test(match);
+      const hasDigit = /\d/.test(match);
+      return (hasLower && hasUpper && hasDigit) ? '[REDACTED]' : match;
+    });
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────
+
+/**
+ * Bridges inbound Discord messages from the shared DiscordChannelAdapter to
+ * the internal EventBus. Publishes `discord:message` for normal messages
+ * and `discord:mention` when the bot user is @mentioned.
+ *
+ * Security layers:
+ *   1. Bot filter (defense in depth — adapter already drops bots, but we
+ *      re-check here so a future adapter change can't leak bot messages).
+ *   2. Optional DISCORD_ALLOWED_CHANNEL_IDS allowlist — fail-open if unset.
+ *   3. Message-ID dedup (bounded in-memory cache).
+ *   4. Secret redaction on message text before publishing.
+ *
+ * This is NOT a webhook route — Discord uses a persistent gateway
+ * connection via discord.js. The handler registers via adapter.listen().
+ */
+export class DiscordEventHandler {
+  private recentMessageIds = new Set<string>();
+  private readonly allowedChannels: Set<string> | null;
+
+  constructor(
+    private readonly eventBus: EventBus,
+    private readonly adapter: DiscordChannelAdapter,
+  ) {
+    const raw = process.env.DISCORD_ALLOWED_CHANNEL_IDS;
+    this.allowedChannels = raw
+      ? new Set(raw.split(',').map((s) => s.trim()).filter(Boolean))
+      : null;
+
+    logger.info('DiscordEventHandler initialized', {
+      allowedChannels: this.allowedChannels?.size ?? 'all',
+    });
+  }
+
+  /** Register the inbound listener with the shared adapter. */
+  async start(): Promise<void> {
+    await this.adapter.listen(async (inbound) => {
+      try {
+        await this.handleMessage(inbound);
+      } catch (err) {
+        // Never let a handler exception propagate into the discord.js event
+        // loop — it would kill the gateway reader.
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error('Discord event handler threw', {
+          messageId: inbound.messageId,
+          error: msg,
+        });
+      }
+    });
+    logger.info('DiscordEventHandler listener registered');
+  }
+
+  // ─── Core pipeline ──────────────────────────────────────────────────────
+
+  private async handleMessage(inbound: InboundMessage): Promise<void> {
+    const raw = inbound.raw as
+      | {
+          author?: { bot?: boolean; id?: string; username?: string };
+          guildId?: string | null;
+          channel?: { parentId?: string | null; isThread?: () => boolean };
+          mentions?: {
+            users?: { has: (id: string) => boolean; size?: number };
+            has?: (user: unknown) => boolean;
+          };
+          client?: { user?: { id?: string } };
+        }
+      | undefined;
+
+    // 1. Belt-and-suspenders bot filter.
+    if (raw?.author?.bot === true) {
+      logger.debug('Dropping Discord bot message', { messageId: inbound.messageId });
+      return;
+    }
+
+    // 2. Dedup by message ID.
+    if (this.recentMessageIds.has(inbound.messageId)) {
+      logger.debug('Dropping duplicate Discord message', { messageId: inbound.messageId });
+      return;
+    }
+    this.recentMessageIds.add(inbound.messageId);
+    if (this.recentMessageIds.size > MAX_EVENT_CACHE * 2) {
+      const entries = [...this.recentMessageIds];
+      this.recentMessageIds = new Set(entries.slice(-MAX_EVENT_CACHE));
+    }
+
+    // 3. Determine thread context and parent channel.
+    const threadId = inbound.threadId ?? null;
+    const parentChannelId = raw?.channel?.parentId ?? null;
+    const isThread = threadId !== null && threadId !== undefined;
+    // For thread messages, the effective "channel" for allowlist purposes
+    // is the parent text channel, not the thread itself.
+    const effectiveChannelId = isThread && parentChannelId
+      ? parentChannelId
+      : inbound.channelId;
+
+    // 4. Channel allowlist — fail-open if unset.
+    if (this.allowedChannels && !this.allowedChannels.has(effectiveChannelId)) {
+      logger.debug('Dropping Discord message from non-allowed channel', {
+        messageId: inbound.messageId,
+        channelId: inbound.channelId,
+        effectiveChannelId,
+      });
+      return;
+    }
+
+    // 5. Mention detection — check if the bot user is in the mention list.
+    let isMention = false;
+    const botUserId = raw?.client?.user?.id;
+    if (botUserId && raw?.mentions?.users?.has) {
+      try {
+        isMention = raw.mentions.users.has(botUserId);
+      } catch {
+        isMention = false;
+      }
+    }
+
+    // 6. Secret redaction.
+    const redactedText = redact(inbound.text ?? '');
+
+    // 7. Build event payload.
+    const payload: Record<string, unknown> = {
+      channel: inbound.channelId, // no reverse map; the raw ID doubles as name
+      channelId: inbound.channelId,
+      threadId,
+      parentChannelId,
+      isThread,
+      user: inbound.displayName ?? raw?.author?.username ?? 'unknown',
+      userId: inbound.userId,
+      text: redactedText,
+      messageId: inbound.messageId,
+      isMention,
+      guildId: raw?.guildId ?? null,
+      timestamp: inbound.timestamp,
+    };
+
+    // 8. Publish to EventBus.
+    const eventType = isMention ? 'mention' : 'message';
+    logger.info('Publishing discord event', {
+      type: `discord:${eventType}`,
+      channelId: inbound.channelId,
+      isThread,
+    });
+    await this.eventBus.publish('discord', eventType, payload);
+  }
+}

--- a/packages/core/tests/discord-event-handler.test.ts
+++ b/packages/core/tests/discord-event-handler.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InboundMessage, InboundMessageHandler } from '../src/interfaces/IChannel.js';
+
+vi.mock('../src/logging/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const { DiscordEventHandler } = await import('../src/triggers/discord-event-handler.js');
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function createMockEventBus() {
+  return {
+    publish: vi.fn(async () => undefined),
+  } as any;
+}
+
+function createMockAdapter() {
+  let capturedHandler: InboundMessageHandler | null = null;
+  return {
+    name: 'discord',
+    listen: vi.fn(async (handler: InboundMessageHandler) => {
+      capturedHandler = handler;
+    }),
+    getCapturedHandler: (): InboundMessageHandler | null => capturedHandler,
+    send: vi.fn(),
+    healthy: vi.fn(async () => true),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as any;
+}
+
+const BOT_USER_ID = 'bot-user-9999';
+const ALICE_USER_ID = 'user-alice';
+const PARENT_CHANNEL_ID = '1489421589941325904';
+const OTHER_CHANNEL_ID = '1489421500000000000';
+const THREAD_CHANNEL_ID = '1489421599999999999';
+
+function baseRaw(overrides: Record<string, unknown> = {}) {
+  return {
+    author: { id: ALICE_USER_ID, username: 'alice', bot: false },
+    guildId: 'guild-1',
+    channel: { parentId: null, isThread: () => false },
+    mentions: {
+      users: { has: (_id: string) => false, size: 0 },
+    },
+    client: { user: { id: BOT_USER_ID } },
+    ...overrides,
+  };
+}
+
+function makeInbound(overrides: Partial<InboundMessage> = {}, raw?: Record<string, unknown>): InboundMessage {
+  return {
+    messageId: 'msg-' + Math.random().toString(36).slice(2, 8),
+    channelId: PARENT_CHANNEL_ID,
+    userId: ALICE_USER_ID,
+    displayName: 'alice',
+    text: 'hello world',
+    threadId: undefined,
+    timestamp: new Date().toISOString(),
+    raw: raw ?? baseRaw(),
+    ...overrides,
+  };
+}
+
+// ─── Env snapshot ──────────────────────────────────────────────────────────
+
+function snapshotEnv(keys: string[]): Record<string, string | undefined> {
+  const s: Record<string, string | undefined> = {};
+  for (const k of keys) s[k] = process.env[k];
+  return s;
+}
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const [k, v] of Object.entries(snap)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('DiscordEventHandler', () => {
+  let eventBus: ReturnType<typeof createMockEventBus>;
+  let adapter: ReturnType<typeof createMockAdapter>;
+  let handler: InstanceType<typeof DiscordEventHandler>;
+  let envSnap: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envSnap = snapshotEnv(['DISCORD_ALLOWED_CHANNEL_IDS']);
+    delete process.env.DISCORD_ALLOWED_CHANNEL_IDS;
+    eventBus = createMockEventBus();
+    adapter = createMockAdapter();
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnap);
+  });
+
+  async function startAndGet(): Promise<InboundMessageHandler> {
+    handler = new DiscordEventHandler(eventBus, adapter);
+    await handler.start();
+    expect(adapter.listen).toHaveBeenCalledTimes(1);
+    const fn = adapter.getCapturedHandler();
+    if (!fn) throw new Error('handler not registered');
+    return fn;
+  }
+
+  // ─── Basic routing ──────────────────────────────────────────────────
+
+  it('publishes discord:message for a normal message', async () => {
+    const inbound = makeInbound({ text: 'good morning' });
+    const fn = await startAndGet();
+    await fn(inbound);
+
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    const [source, type, payload] = eventBus.publish.mock.calls[0];
+    expect(source).toBe('discord');
+    expect(type).toBe('message');
+    expect(payload.text).toBe('good morning');
+    expect(payload.isMention).toBe(false);
+    expect(payload.isThread).toBe(false);
+  });
+
+  it('publishes discord:mention when the bot user is mentioned', async () => {
+    const raw = baseRaw({
+      mentions: { users: { has: (id: string) => id === BOT_USER_ID, size: 1 } },
+    });
+    const fn = await startAndGet();
+    await fn(makeInbound({ text: '@bot help' }, raw));
+
+    const [source, type, payload] = eventBus.publish.mock.calls[0];
+    expect(source).toBe('discord');
+    expect(type).toBe('mention');
+    expect(payload.isMention).toBe(true);
+  });
+
+  // ─── Bot filtering ──────────────────────────────────────────────────
+
+  it('drops bot messages (defense in depth)', async () => {
+    const raw = baseRaw({ author: { id: 'bot-99', username: 'otherbot', bot: true } });
+    const fn = await startAndGet();
+    await fn(makeInbound({}, raw));
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  // ─── Dedup ──────────────────────────────────────────────────────────
+
+  it('drops duplicate message IDs', async () => {
+    const fn = await startAndGet();
+    const dup = makeInbound({ messageId: 'same-id' });
+    await fn(dup);
+    await fn(dup);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── Channel allowlist ─────────────────────────────────────────────
+
+  it('allowlist unset → all channels allowed', async () => {
+    const fn = await startAndGet();
+    await fn(makeInbound({ channelId: OTHER_CHANNEL_ID }));
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('allowlist set → blocks non-allowed channels', async () => {
+    process.env.DISCORD_ALLOWED_CHANNEL_IDS = PARENT_CHANNEL_ID;
+    const fn = await startAndGet();
+    await fn(makeInbound({ channelId: OTHER_CHANNEL_ID }));
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('allowlist set → permits allowed channels', async () => {
+    process.env.DISCORD_ALLOWED_CHANNEL_IDS = PARENT_CHANNEL_ID;
+    const fn = await startAndGet();
+    await fn(makeInbound({ channelId: PARENT_CHANNEL_ID }));
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('thread messages check allowlist against parent channel ID', async () => {
+    process.env.DISCORD_ALLOWED_CHANNEL_IDS = PARENT_CHANNEL_ID;
+    const raw = baseRaw({ channel: { parentId: PARENT_CHANNEL_ID, isThread: () => true } });
+    const fn = await startAndGet();
+    await fn(
+      makeInbound(
+        { channelId: THREAD_CHANNEL_ID, threadId: THREAD_CHANNEL_ID },
+        raw,
+      ),
+    );
+    // Should be ALLOWED because parent is in the allowlist, even though the
+    // thread channel ID itself isn't.
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    const [, , payload] = eventBus.publish.mock.calls[0];
+    expect(payload.isThread).toBe(true);
+    expect(payload.threadId).toBe(THREAD_CHANNEL_ID);
+    expect(payload.parentChannelId).toBe(PARENT_CHANNEL_ID);
+  });
+
+  // ─── Secret redaction ───────────────────────────────────────────────
+
+  it('redacts OpenAI-style keys', async () => {
+    const fn = await startAndGet();
+    await fn(makeInbound({ text: 'here is my key sk-abcdef1234567890abcdef1234567890' }));
+    const [, , payload] = eventBus.publish.mock.calls[0];
+    expect(payload.text).toContain('[REDACTED]');
+    expect(payload.text).not.toContain('sk-abcdef');
+  });
+
+  it('redacts GitHub PAT tokens', async () => {
+    const fn = await startAndGet();
+    await fn(makeInbound({ text: 'token: ghp_abcdefghijklmnopqrstuvwxyz0123456789' }));
+    const [, , payload] = eventBus.publish.mock.calls[0];
+    expect(payload.text).toContain('[REDACTED]');
+    expect(payload.text).not.toContain('ghp_abc');
+  });
+
+  it('redacts AWS access keys', async () => {
+    const fn = await startAndGet();
+    await fn(makeInbound({ text: 'creds: AKIAIOSFODNN7EXAMPLE done' }));
+    const [, , payload] = eventBus.publish.mock.calls[0];
+    expect(payload.text).toContain('[REDACTED]');
+    expect(payload.text).not.toContain('AKIAIOSFODNN7EXAMPLE');
+  });
+
+  it('does not mangle normal chat text', async () => {
+    const fn = await startAndGet();
+    await fn(makeInbound({ text: 'This is a perfectly normal sentence about the weather today.' }));
+    const [, , payload] = eventBus.publish.mock.calls[0];
+    expect(payload.text).toBe('This is a perfectly normal sentence about the weather today.');
+  });
+
+  // ─── Robustness ─────────────────────────────────────────────────────
+
+  it('handles missing or partial raw payload without crashing', async () => {
+    const fn = await startAndGet();
+    await expect(fn(makeInbound({ raw: undefined }))).resolves.not.toThrow();
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── Payload shape ──────────────────────────────────────────────────
+
+  it('emits the expected payload shape', async () => {
+    const fn = await startAndGet();
+    await fn(
+      makeInbound({
+        messageId: 'msg-shape',
+        channelId: PARENT_CHANNEL_ID,
+        userId: ALICE_USER_ID,
+        displayName: 'alice',
+        text: 'shape test',
+        timestamp: '2026-04-08T12:00:00.000Z',
+      }),
+    );
+    const [, , payload] = eventBus.publish.mock.calls[0];
+    expect(payload).toMatchObject({
+      channelId: PARENT_CHANNEL_ID,
+      threadId: null,
+      parentChannelId: null,
+      isThread: false,
+      user: 'alice',
+      userId: ALICE_USER_ID,
+      text: 'shape test',
+      messageId: 'msg-shape',
+      isMention: false,
+      guildId: 'guild-1',
+      timestamp: '2026-04-08T12:00:00.000Z',
+    });
+  });
+
+  // ─── start() wiring ─────────────────────────────────────────────────
+
+  it('start() registers the listener on the adapter', async () => {
+    handler = new DiscordEventHandler(eventBus, adapter);
+    await handler.start();
+    expect(adapter.listen).toHaveBeenCalledTimes(1);
+    expect(adapter.getCapturedHandler()).not.toBeNull();
+  });
+});

--- a/packages/core/tests/discord-executor.test.ts
+++ b/packages/core/tests/discord-executor.test.ts
@@ -1,0 +1,404 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DiscordChannelAdapter } from '../src/adapters/channels/DiscordChannelAdapter.js';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('../src/logging/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const {
+  DiscordExecutor,
+  DISCORD_CHANNELS,
+  DISCORD_AGENT_IDENTITIES,
+} = await import('../src/actions/discord.js');
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function createMockAdapter(): DiscordChannelAdapter & {
+  send: ReturnType<typeof vi.fn>;
+  createThread: ReturnType<typeof vi.fn>;
+  react: ReturnType<typeof vi.fn>;
+  fetchChannelHistory: ReturnType<typeof vi.fn>;
+  fetchThreadReplies: ReturnType<typeof vi.fn>;
+  healthy: ReturnType<typeof vi.fn>;
+} {
+  const adapter = {
+    name: 'discord',
+    send: vi.fn(async () => ({ success: true, messageId: 'msg-1' })),
+    createThread: vi.fn(async () => ({ threadId: 'thread-1', channelId: 'chan-1' })),
+    react: vi.fn(async () => undefined),
+    fetchChannelHistory: vi.fn(async () => [
+      { id: 'm1', author: { id: 'u1', username: 'alice', bot: false }, content: 'hi', createdAt: new Date().toISOString(), threadId: null },
+    ]),
+    fetchThreadReplies: vi.fn(async () => [
+      { id: 'm2', author: { id: 'u2', username: 'bob', bot: false }, content: 'yo', createdAt: new Date().toISOString(), threadId: 'thread-1' },
+    ]),
+    healthy: vi.fn(async () => true),
+    isConnected: vi.fn(() => true),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    listen: vi.fn(),
+    supportsInboundListening: () => true,
+    supportsReactions: () => true,
+    supportsThreads: () => true,
+    supportsFileUpload: () => true,
+    supportsIdentityOverride: () => false,
+  };
+  return adapter as any;
+}
+
+/**
+ * In-memory Redis mock exposing just the subset DiscordExecutor uses:
+ * - get(key)
+ * - set(key, value, 'EX', ttl, 'NX')
+ * - incr(key)
+ * - expire(key, ttl)
+ */
+function createMockRedis(): {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  incr: ReturnType<typeof vi.fn>;
+  expire: ReturnType<typeof vi.fn>;
+  _store: Map<string, string>;
+} {
+  const store = new Map<string, string>();
+  const set = vi.fn(async (...args: unknown[]) => {
+    const key = args[0] as string;
+    const value = args[1] as string;
+    const nx = args[args.length - 1] === 'NX';
+    if (nx && store.has(key)) return null;
+    store.set(key, value);
+    return 'OK';
+  });
+  const get = vi.fn(async (key: string) => store.get(key) ?? null);
+  const incr = vi.fn(async (key: string) => {
+    const next = (parseInt(store.get(key) ?? '0', 10)) + 1;
+    store.set(key, String(next));
+    return next;
+  });
+  const expire = vi.fn(async () => 1);
+  return { get, set, incr, expire, _store: store } as any;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('DiscordExecutor', () => {
+  let adapter: ReturnType<typeof createMockAdapter>;
+  let redis: ReturnType<typeof createMockRedis>;
+  let executor: InstanceType<typeof DiscordExecutor>;
+
+  beforeEach(() => {
+    adapter = createMockAdapter();
+    redis = createMockRedis();
+    executor = new DiscordExecutor(adapter as unknown as DiscordChannelAdapter, redis as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── Tool Definitions ────────────────────────────────────────────────
+
+  it('getToolDefinitions returns all 7 expected tool definitions', () => {
+    const defs = executor.getToolDefinitions();
+    const names = defs.map((d) => d.name).sort();
+    expect(names).toEqual([
+      'discord:alert',
+      'discord:create_thread',
+      'discord:get_channel_history',
+      'discord:get_thread',
+      'discord:message',
+      'discord:react',
+      'discord:thread_reply',
+    ]);
+  });
+
+  it('never exposes discord:dm in the tool list', () => {
+    const defs = executor.getToolDefinitions();
+    expect(defs.find((d) => d.name === 'discord:dm')).toBeUndefined();
+  });
+
+  // ─── discord:message ────────────────────────────────────────────────
+
+  it('discord:message rejects missing channel or text', async () => {
+    const noChannel = await executor.execute('message', { text: 'hi' });
+    expect(noChannel.success).toBe(false);
+    expect(noChannel.error).toMatch(/channel/);
+
+    const noText = await executor.execute('message', { channel: 'general' });
+    expect(noText.success).toBe(false);
+    expect(noText.error).toMatch(/text/);
+  });
+
+  it('discord:message rejects text over 600 characters', async () => {
+    const long = 'x'.repeat(601);
+    const result = await executor.execute('message', {
+      channel: 'general',
+      text: long,
+      agentName: 'keeper',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('600 character limit');
+    expect(adapter.send).not.toHaveBeenCalled();
+  });
+
+  it('discord:message accepts symbolic channel names from DISCORD_CHANNELS', async () => {
+    const result = await executor.execute('message', {
+      channel: 'support',
+      text: 'hello',
+      agentName: 'keeper',
+    });
+    expect(result.success).toBe(true);
+    const [target] = adapter.send.mock.calls[0];
+    expect(target.channelId).toBe(DISCORD_CHANNELS.support);
+  });
+
+  it('discord:message accepts raw snowflake IDs', async () => {
+    const snowflake = '1489421589941325904';
+    const result = await executor.execute('message', {
+      channel: snowflake,
+      text: 'hello',
+      agentName: 'keeper',
+    });
+    expect(result.success).toBe(true);
+    expect(adapter.send.mock.calls[0][0].channelId).toBe(snowflake);
+  });
+
+  it('discord:message rejects unknown symbolic channel names', async () => {
+    const result = await executor.execute('message', {
+      channel: 'not-a-real-channel',
+      text: 'hi',
+      agentName: 'keeper',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Unknown Discord channel/);
+  });
+
+  it('discord:message injects agent identity for known agents', async () => {
+    await executor.execute('message', {
+      channel: 'support',
+      text: 'hello',
+      agentName: 'keeper',
+    });
+    const [, msg] = adapter.send.mock.calls[0];
+    expect(msg.identity?.displayName).toBe(DISCORD_AGENT_IDENTITIES.keeper!.displayName);
+  });
+
+  // ─── Rate limiting ─────────────────────────────────────────────────
+
+  it('enforces per-channel cooldown on rapid messages', async () => {
+    const first = await executor.execute('message', {
+      channel: '1489421589941325904',
+      text: 'hello world',
+      agentName: 'keeper',
+    });
+    expect(first.success).toBe(true);
+    expect(first.data?.suppressed).toBeUndefined();
+
+    const second = await executor.execute('message', {
+      channel: '1489421589941325904',
+      text: 'different text',
+      agentName: 'keeper',
+    });
+    expect(second.success).toBe(true);
+    expect(second.data?.suppressed).toBe(true);
+    expect(second.data?.reason).toBe('rate_limited');
+  });
+
+  it('enforces thread cooldown on rapid thread_reply', async () => {
+    const first = await executor.execute('thread_reply', {
+      channel: 'support',
+      threadId: '1489421600000000000',
+      text: 'first reply',
+      agentName: 'guide',
+    });
+    expect(first.success).toBe(true);
+    expect(first.data?.suppressed).toBeUndefined();
+
+    const second = await executor.execute('thread_reply', {
+      channel: 'support',
+      threadId: '1489421600000000000',
+      text: 'different reply',
+      agentName: 'guide',
+    });
+    expect(second.success).toBe(true);
+    expect(second.data?.suppressed).toBe(true);
+    expect(second.data?.reason).toBe('rate_limited');
+  });
+
+  it('enforces global hourly cap (20/hour/agent)', async () => {
+    // Pre-seed the hourly counter at the cap
+    const bucketKeyPattern = /^discord:hourly:ember:/;
+    for (let i = 0; i < 20; i++) {
+      // Use distinct channels so per-channel cooldown doesn't suppress
+      const distinctChannel = `148942158000000000${i}`;
+      await executor.execute('message', {
+        channel: distinctChannel,
+        text: `msg ${i}`,
+        agentName: 'ember',
+      });
+    }
+    // 21st should trip hourly cap
+    const result = await executor.execute('message', {
+      channel: '1489421580000000099',
+      text: 'over the cap',
+      agentName: 'ember',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.suppressed).toBe(true);
+    expect(result.data?.reason).toBe('rate_limited');
+    expect(result.data?.detail).toMatch(/hourly cap/);
+    expect([...redis._store.keys()].some((k) => bucketKeyPattern.test(k))).toBe(true);
+  });
+
+  it('thread_reply allows long text (no 600 char limit)', async () => {
+    const long = 'x'.repeat(1500);
+    const result = await executor.execute('thread_reply', {
+      channel: 'support',
+      threadId: '1489421600000000001',
+      text: long,
+      agentName: 'guide',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.suppressed).toBeUndefined();
+  });
+
+  // ─── Dedup ──────────────────────────────────────────────────────────
+
+  it('deduplicates identical messages within the window', async () => {
+    const first = await executor.execute('message', {
+      channel: '1489421581111111111',
+      text: 'same content',
+      agentName: 'sentinel',
+    });
+    expect(first.success).toBe(true);
+    expect(first.data?.suppressed).toBeUndefined();
+
+    const second = await executor.execute('message', {
+      channel: '1489421581111111111',
+      text: 'same content',
+      agentName: 'sentinel',
+    });
+    expect(second.success).toBe(true);
+    expect(second.data?.suppressed).toBe(true);
+    expect(second.data?.reason).toBe('duplicate_within_window');
+  });
+
+  // ─── No DM ──────────────────────────────────────────────────────────
+
+  it('rejects user-targeted actions (no DMs)', async () => {
+    const result = await executor.execute('message', {
+      userId: '12345',
+      text: 'secret',
+      agentName: 'keeper',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/DMs are not supported/);
+  });
+
+  it('does not expose a dm action handler', async () => {
+    // Without userId we fall through to the dispatch switch — which should
+    // not have a 'dm' case. With userId we hit the no-DM gate first. Both
+    // paths reject, which is what we want to assert.
+    const noUser = await executor.execute('dm', { channel: 'general', text: 'hi' });
+    expect(noUser.success).toBe(false);
+    expect(noUser.error).toMatch(/Unknown Discord action/);
+  });
+
+  // ─── Fail-open on Redis down ─────────────────────────────────────────
+
+  it('rate limiting fails open when Redis is unavailable', async () => {
+    const adapterNoRedis = createMockAdapter();
+    const execNoRedis = new DiscordExecutor(adapterNoRedis as unknown as DiscordChannelAdapter, null);
+    // Post 25 messages to distinct channels — should all pass since redis is null
+    for (let i = 0; i < 25; i++) {
+      const res = await execNoRedis.execute('message', {
+        channel: `148942158${String(i).padStart(9, '0')}`,
+        text: `msg ${i}`,
+        agentName: 'keeper',
+      });
+      expect(res.success).toBe(true);
+      expect(res.data?.suppressed).toBeUndefined();
+    }
+    expect(adapterNoRedis.send).toHaveBeenCalledTimes(25);
+  });
+
+  // ─── Other actions ──────────────────────────────────────────────────
+
+  it('discord:create_thread delegates to adapter.createThread', async () => {
+    const result = await executor.execute('create_thread', {
+      channel: '1489421582222222222',
+      messageId: '9999999999',
+      name: 'Test Thread',
+    });
+    expect(result.success).toBe(true);
+    expect(adapter.createThread).toHaveBeenCalledWith(
+      { messageId: '9999999999', channelId: '1489421582222222222' },
+      'Test Thread',
+    );
+    expect(result.data?.threadId).toBe('thread-1');
+  });
+
+  it('discord:react delegates to adapter.react', async () => {
+    const result = await executor.execute('react', {
+      channel: '1489421583333333333',
+      messageId: '8888888888',
+      emoji: '👍',
+    });
+    expect(result.success).toBe(true);
+    expect(adapter.react).toHaveBeenCalledWith(
+      { messageId: '8888888888', channelId: '1489421583333333333' },
+      '👍',
+    );
+  });
+
+  it('discord:get_channel_history returns normalized messages from adapter', async () => {
+    const result = await executor.execute('get_channel_history', {
+      channel: 'general',
+      limit: 10,
+    });
+    expect(result.success).toBe(true);
+    expect(adapter.fetchChannelHistory).toHaveBeenCalledWith(DISCORD_CHANNELS.general, 10);
+    expect(Array.isArray(result.data?.messages)).toBe(true);
+  });
+
+  it('discord:get_thread returns normalized messages from adapter', async () => {
+    const result = await executor.execute('get_thread', {
+      threadId: '1489421584444444444',
+      limit: 5,
+    });
+    expect(result.success).toBe(true);
+    expect(adapter.fetchThreadReplies).toHaveBeenCalledWith('1489421584444444444', 5);
+  });
+
+  it('discord:alert posts a formatted embed-style message', async () => {
+    const result = await executor.execute('alert', {
+      channel: '1489421585555555555',
+      text: 'System is down',
+      severity: 'critical',
+      title: 'Outage',
+      agentName: 'sentinel',
+    });
+    expect(result.success).toBe(true);
+    const [, msg] = adapter.send.mock.calls[0];
+    expect(msg.text).toContain('Outage');
+    expect(msg.text).toContain('System is down');
+    expect(msg.text).toContain('🚨'); // critical emoji
+  });
+
+  // ─── Health check ───────────────────────────────────────────────────
+
+  it('healthCheck delegates to adapter.healthy', async () => {
+    adapter.healthy.mockResolvedValueOnce(true);
+    expect(await executor.healthCheck()).toBe(true);
+
+    adapter.healthy.mockResolvedValueOnce(false);
+    expect(await executor.healthCheck()).toBe(false);
+  });
+});

--- a/packages/core/tests/discord-executor.test.ts
+++ b/packages/core/tests/discord-executor.test.ts
@@ -54,17 +54,22 @@ function createMockAdapter(): DiscordChannelAdapter & {
 }
 
 /**
- * In-memory Redis mock exposing just the subset DiscordExecutor uses:
+ * In-memory Redis mock exposing the subset DiscordExecutor uses:
  * - get(key)
  * - set(key, value, 'EX', ttl, 'NX')
  * - incr(key)
  * - expire(key, ttl)
+ * - eval(script, numKeys, ...keysAndArgs) — the rate-limit path runs a
+ *   Lua script with 2 keys (hourKey, cooldownKey) and 3 args (hourlyCap,
+ *   cooldownSeconds, hourlyWindowS). Only the check-and-consume logic is
+ *   simulated here; if you add new scripts, extend this mock.
  */
 function createMockRedis(): {
   get: ReturnType<typeof vi.fn>;
   set: ReturnType<typeof vi.fn>;
   incr: ReturnType<typeof vi.fn>;
   expire: ReturnType<typeof vi.fn>;
+  eval: ReturnType<typeof vi.fn>;
   _store: Map<string, string>;
 } {
   const store = new Map<string, string>();
@@ -83,7 +88,27 @@ function createMockRedis(): {
     return next;
   });
   const expire = vi.fn(async () => 1);
-  return { get, set, incr, expire, _store: store } as any;
+  const evalFn = vi.fn(async (
+    _script: string,
+    _numKeys: number,
+    hourKey: string,
+    cooldownKey: string,
+    hourlyCap: string,
+    cooldownSeconds: string,
+    _hourlyWindowS: string,
+  ) => {
+    const cap = parseInt(hourlyCap, 10);
+    const count = parseInt(store.get(hourKey) ?? '0', 10);
+    if (count >= cap) return 'hourly_cap';
+    if (store.has(cooldownKey)) return 'cooldown';
+    // Set cooldown with TTL (ignored in mock, just track presence)
+    store.set(cooldownKey, '1');
+    void cooldownSeconds; // kept for parity with prod signature
+    // Increment hour count
+    store.set(hourKey, String(count + 1));
+    return 'ok';
+  });
+  return { get, set, incr, expire, eval: evalFn, _store: store } as any;
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a full Discord integration on top of the `ChannelNotifier` work in #5. Agents can now post to, react in, read from, and handle inbound mentions/messages from Discord using the same shared `DiscordChannelAdapter` already created by `InfrastructureFactory`.

Spec: \`discord-integration-prompt.md\`.

**Critical design rule honored:** exactly one Discord gateway connection. The executor and the event handler both look up \`services.infrastructure?.channels.get('discord')\` and share that adapter. No second client.

## What's in it

### New modules

- \`packages/core/src/actions/discord.ts\` — \`DiscordExecutor\` exposing 7 agent tools:
  - \`discord:message\` (600-char public limit, rate limited)
  - \`discord:thread_reply\` (Discord native 2000-char limit)
  - \`discord:create_thread\`
  - \`discord:get_channel_history\` (read-only)
  - \`discord:get_thread\` (read-only)
  - \`discord:react\`
  - \`discord:alert\` (severity-tagged formatted markdown)
  - \`DISCORD_CHANNELS\` placeholder map (operator must replace snowflake IDs post-deploy)
  - \`DISCORD_AGENT_IDENTITIES\` map for display-name overrides per agent

- \`packages/core/src/triggers/discord-event-handler.ts\` — bridges inbound adapter messages to the \`EventBus\` as \`discord:message\` or \`discord:mention\`. Not a webhook route — Discord uses a persistent gateway, so the handler registers via \`adapter.listen()\`.

### Guardrails (all enforced, not just documented)

**Executor**
- **Channel cooldown**: 90s per \`{agent, channelId}\` pair (Redis-backed, fail-open).
- **Thread cooldown**: 30s per \`{agent, threadId}\` pair.
- **Global hourly cap**: 20 msgs/hour/agent.
- **Message length**: 600 char hard limit on public-channel messages; threads exempt.
- **Deduplication**: sha256 fingerprint of normalized \`(channel, text)\`, 1h window. Snowflake normalization added on top of the Slack fingerprint.
- **No DMs**: any user-targeted action short-circuits with a clear error. No \`discord:dm\` action exists.
- **Channel resolution**: accepts symbolic names from \`DISCORD_CHANNELS\` or raw snowflakes (17–20 digits).

**Event handler**
- **Bot filter**: belt-and-suspenders — the adapter already drops bots but we re-check.
- **Dedup**: bounded in-memory set (1000 LRU).
- **Channel allowlist**: \`DISCORD_ALLOWED_CHANNEL_IDS\` env var (comma-separated). Thread messages check the *parent* channel, not the thread.
- **Mention detection**: \`raw.mentions.users.has(client.user.id)\`.
- **Secret redaction**: OpenAI, GitHub PAT/ghp, AWS access keys, Discord bot tokens, high-entropy 40+ char bearer blobs. Conservative — normal chat text is untouched.

### Adapter extension (narrow)

\`DiscordChannelAdapter\` gains three adapter-specific helper methods:
- \`fetchChannelHistory(channelId, limit)\`
- \`fetchThreadReplies(threadId, limit)\`
- \`isConnected()\`

These are NOT on \`IChannel\` — the spec explicitly asks not to widen the interface for Discord-specific concerns. They're typed methods on the concrete adapter class, reachable by the executor.

### Bootstrap wiring

- \`bootstrap/actions.ts\` — looks up the shared adapter, registers \`DiscordExecutor\` wrapping it. Gracefully skips when \`DISCORD_BOT_TOKEN\` is unset (in which case \`InfrastructureFactory\` never creates the adapter).
- \`bootstrap/routes.ts\` — looks up the same shared adapter, starts \`DiscordEventHandler\` on it. Guarded by \`DISCORD_BOT_TOKEN\`.

### Agent permission matrix

| Agent | message | thread_reply | create_thread | get_channel_history | get_thread | react | alert | Triggers |
|---|---|---|---|---|---|---|---|---|
| **Keeper** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | \`discord:message\` + \`discord:mention\` |
| **Guide** | — | ✅ | — | — | ✅ | ✅ | — | \`discord:mention\` only |
| **Sentinel** | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ | \`discord:mention\` only |
| **Ember** | — | — | — | ✅ | — | — | — | \`discord:message\` (read-only) |
| **Scout** | — | — | — | ✅ | — | — | — | \`discord:message\` (read-only) |

Ember/Scout monitor Discord for sentiment/intel but write summaries to **Slack** internal channels only, per the spec.

### Tests

- \`tests/discord-executor.test.ts\` — 22 cases covering tool defs, guardrails (length, dedup, channel cooldown, thread cooldown, hourly cap, no DM, unknown channel names), action dispatch (message, thread_reply, create_thread, react, get_channel_history, get_thread, alert), identity injection, fail-open on no Redis, health check delegation.
- \`tests/discord-event-handler.test.ts\` — 15 cases covering routing (message/mention), bot filter, dedup, allowlist (unset/allowed/blocked/thread-via-parent), secret redaction (openai/ghp/aws/benign), partial raw payload robustness, payload shape, \`start()\` wiring.

**1648 / 1648 tests passing**, clean \`tsc --noEmit\`, clean build.

## Env vars (all optional except the bot token)

| Variable | Required | Description |
|---|---|---|
| \`DISCORD_BOT_TOKEN\` | Yes | Discord bot token (enables the whole Discord path) |
| \`DISCORD_ALLOWED_CHANNEL_IDS\` | No | Comma-separated channel snowflakes to allow (all if unset) |
| \`REDIS_URL\` | No | Shared with Slack — enables rate limiting + dedup; fail-open if missing |

## Test Plan

- [ ] Create a Discord bot at https://discord.com/developers/applications, copy \`DISCORD_BOT_TOKEN\`.
- [ ] Invite the bot to the YCLAW server with intents: Guilds, GuildMessages, MessageContent, DirectMessages.
- [ ] Replace placeholder IDs in \`DISCORD_CHANNELS\` (\`packages/core/src/actions/discord.ts\`) with real snowflakes.
- [ ] Create the 4 internal channels: \`#agent-observations\`, \`#agent-escalations\`, \`#agent-review-queue\`, \`#agent-audit-log\`.
- [ ] Set \`DISCORD_BOT_TOKEN\` in \`.env\` and boot \`docker compose up -d\`.
- [ ] Watch \`docker compose logs api | grep -i discord\` for:
  - \`DiscordExecutor initialized\`
  - \`Discord executor registered (sharing adapter from infrastructure.channels)\`
  - \`DiscordEventHandler initialized\`
  - \`DiscordEventHandler listener registered\`
- [ ] Post a normal message in a monitored channel — verify \`discord:message\` event flows to Ember/Scout subscriptions.
- [ ] @mention the bot — verify \`discord:mention\` routes to Keeper/Guide/Sentinel.
- [ ] Invoke \`discord:message\` from an agent tool call — verify it respects the 600-char limit and rate limits.
- [ ] Paste a fake \`sk-abcdef...\` key into a message — verify the published event shows \`[REDACTED]\`.
- [ ] Blank out \`DISCORD_BOT_TOKEN\`, restart — verify the handler and executor skip gracefully.

## Interaction with PR #5

PR #5 added \`ChannelNotifier\` and the \`DiscordChannelAdapter\` wiring in \`InfrastructureFactory\`. This PR reuses that adapter — no conflict, no duplicate clients. The three Discord consumers are now:
1. **ChannelNotifier** (outbound coord.* events, from #5)
2. **DiscordExecutor** (agent tool calls, this PR)
3. **DiscordEventHandler** (inbound messages, this PR)

All three share one \`discord.js\` Client via \`infrastructure.channels.get('discord')\`.

## Post-merge operator checklist

After merge and deploy, operators must:
1. Replace placeholder channel IDs in \`DISCORD_CHANNELS\` with real snowflakes.
2. Set \`DISCORD_BOT_TOKEN\` in production env vars / secrets manager.
3. Create the 4 internal channels and invite the bot.
4. Set agent avatar URLs in \`DISCORD_AGENT_IDENTITIES\`.
5. Update server rules / channel topics to disclose the AI agent presence.
6. Optionally set \`DISCORD_ALLOWED_CHANNEL_IDS\` as a production safety allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)