### PR TITLE
fix: correct canonical repo casing in deploy.yml if: guards

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,7 +160,7 @@ jobs:
       id-token: write
       contents: read
     if: >-
-      github.repository == 'YClawAI/yclaw'
+      github.repository == 'YClawAI/YClaw'
       && (
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.core == 'true')
         || github.event_name == 'workflow_dispatch'
@@ -287,7 +287,7 @@ jobs:
       id-token: write
       contents: read
     if: >-
-      github.repository == 'YClawAI/yclaw'
+      github.repository == 'YClawAI/YClaw'
       && (
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.mc == 'true')
         || github.event_name == 'workflow_dispatch'
@@ -390,7 +390,7 @@ jobs:
       id-token: write
       contents: read
     if: >-
-      github.repository == 'YClawAI/yclaw'
+      github.repository == 'YClawAI/YClaw'
       && (
         (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.ao == 'true')
         || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
- All three deploy jobs in `deploy.yml` (Core, Mission Control, AO) gate on `github.repository == 'YClawAI/yclaw'`, but the canonical repo name is `YClawAI/YClaw` (capital W). `github.repository` comparisons in workflow `if:` expressions are case-sensitive, so every deploy has been silently skipped on `push` and `workflow_dispatch`.
- Matching the canonical casing on all three guards unblocks the pipeline so newly provisioned ECS services (yclaw-production, yclaw-mc-production, yclaw-ao-production) can actually receive images from ECR.

## Why this is urgent
The AWS infrastructure (OIDC role, ECR repos, ECS cluster + task defs + services) was just provisioned in account `862974744285` per the YCLAW AWS infra setup spec. Until this casing fix lands, the deploy workflow will continue to no-op on every push, and none of the provisioned infra will ever receive an image.

## Protected path
`.github/workflows/**` is a protected path per `CLAUDE.md`. The Agent Safety Guard CI check will require a `human-approved` label on this PR before it can merge.

## Test plan
- [ ] CI: Agent Safety Guard flags the protected-path change (expected)
- [ ] Add `human-approved` label after human review
- [ ] After merge, run `gh workflow run deploy.yml --repo YClawAI/YClaw` and confirm all three deploy jobs evaluate the `if:` to true and proceed past the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)