### PR TITLE
fix: switch core image to Alpine, add Trivy to MC/AO pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -325,17 +325,45 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
-      - name: Build and push image
+      - name: Build image (local only — scan before push)
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
           file: packages/mission-control/Dockerfile
-          push: true
+          push: false
+          load: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
           cache-from: type=gha,scope=mc
           cache-to: type=gha,mode=max,scope=mc
+
+      - name: Trivy vulnerability scan (before push)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-results-mc.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+          ignore-unfixed: true
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@f6c3d0fe42c3cf876e3462574e4c9416b5e0f07a # v0.9.0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom-mc
+          path: sbom.spdx.json
+
+      - name: Push image to ECR (after scan passes)
+        run: |
+          docker push ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          docker push ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
 
       - name: Register new task definition and deploy
         env:
@@ -428,17 +456,49 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
-      - name: Build and push image
+      - name: Build image (local only — scan before push)
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: ao
           file: ao/Dockerfile
-          push: true
+          push: false
+          load: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
           cache-from: type=gha,scope=ao
           cache-to: type=gha,mode=max,scope=ao
+
+      # TODO: Switch AO to Alpine to enable exit-code: '1' here.
+      # AO uses Debian with heavy system deps (tmux, gh, terraform, aws-cli) that
+      # don't have clean Alpine equivalents yet. Scan runs in warning-only mode
+      # until AO is migrated.
+      - name: Trivy vulnerability scan (warning-only)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-results-ao.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+          ignore-unfixed: true
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@f6c3d0fe42c3cf876e3462574e4c9416b5e0f07a # v0.9.0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom-ao
+          path: sbom.spdx.json
+
+      - name: Push image to ECR (after scan)
+        run: |
+          docker push ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          docker push ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
 
       - name: Register new task definition and deploy
         env:

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# YCLAW Trivy Ignore List
+# Only add CVEs here with documented justification.
+# Each entry must include: CVE ID, affected package, reason for ignoring, review date.
+# Policy: exit-code=1 on CRITICAL/HIGH with fixes available. No blanket ignores.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@
 
 # SECURITY: Pin base images to SHA256 digests for immutable builds.
 # Tags are mutable — Renovate will auto-update digests via pinDigests: true.
-# To manually pin: docker manifest inspect node:20-slim | jq -r '.config.digest'
+# To manually pin: docker manifest inspect node:20-alpine | jq -r '.config.digest'
 
 # --- Stage 1: Production dependencies only ---
 # Separate stage so the runner gets a clean node_modules without devDependencies.
 # Saves ~200MB vs copying the full builder node_modules.
-FROM node:20-slim AS prod-deps
+FROM node:20-alpine AS prod-deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 # Copy ALL workspace manifests to satisfy lockfile workspace references.
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev --ignore-scripts \
     && npm rebuild argon2 2>/dev/null || true
 
 # --- Stage 2: Build (needs devDependencies for tsc, turbo, etc.) ---
-FROM node:20-slim AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json turbo.json tsconfig.json ./
 # Copy ALL workspace manifests (same rationale as prod-deps)
@@ -44,13 +44,11 @@ COPY packages/memory/migrations packages/memory/migrations
 RUN npx turbo build --filter=@yclaw/core...
 
 # --- Stage 3: Production runner ---
-FROM node:20-slim AS runner
+FROM node:20-alpine AS runner
 WORKDIR /app
 
-# System packages: curl (health checks), gosu (privilege drop), git (codegen workspaces)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl gosu git ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+# System packages: curl (health checks), su-exec (privilege drop), git (codegen workspaces)
+RUN apk add --no-cache curl su-exec git ca-certificates
 
 # CLI coding tools for codegen system.
 # This layer is ~500MB but cached by Docker — only rebuilds when this line changes.
@@ -92,7 +90,7 @@ COPY --chown=node:node skills skills
 # Ensure logs and tmp directories exist and are writable
 RUN mkdir -p logs tmp tmp/codegen && chown -R node:node logs tmp
 
-# Entrypoint runs as root to fix ephemeral volume ownership, then drops to node via gosu
+# Entrypoint runs as root to fix ephemeral volume ownership, then drops to node via su-exec
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,4 +21,4 @@ chown -R node:node /app/departments /app/prompts /app/memory /app/logs /app/tmp
 chown -R node:node /app/tmp/codegen 2>/dev/null || true
 chown node:node /app/packages/core/src/actions/custom 2>/dev/null || true
 
-exec gosu node "$@"
+exec su-exec node "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5800,7 +5800,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
+      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5869,13 +5871,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -9934,7 +9938,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -11228,7 +11234,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {


### PR DESCRIPTION
## What

Council-approved fix for Core Agents deploy failure (Trivy CVE scan blocking push to ECR).

### Changes

**Dockerfile (Core Agents)**
- All 3 stages: `node:20-slim` (Debian Bookworm) → `node:20-alpine`
- `apt-get` → `apk add --no-cache`
- `gosu` → `su-exec` (Alpine equivalent)

**entrypoint.sh**
- `exec gosu node` → `exec su-exec node`

**deploy.yml**
- MC: Added Trivy scan (strict, `exit-code: 1`) + SBOM generation
- AO: Added Trivy scan (warning-only, `exit-code: 0`) + SBOM — AO has heavy Debian deps (tmux, gh, terraform, aws-cli) that block Alpine migration
- Consistent policy across all 3 services

**npm audit fix**
- Fixed: basic-ftp (CRLF injection), brace-expansion (ReDoS), lodash-es (prototype pollution), path-to-regexp (ReDoS)
- Skipped: next (requires breaking major upgrade to v16)

**.trivyignore** (new)
- Policy header established, no CVEs ignored yet

## Why

AI Council (4/4 unanimous): Don't weaken the security gate. Switch to Alpine, fix the root cause. First deploy of an OSS project sets the security culture.

## Notes
- `.github/workflows/**` is a protected path — needs `human-approved` label to pass CI
- All services are at `desiredCount=0` — no runtime risk