### PR TITLE
fix: use next/link in showcase layout

### DIFF
--- a/packages/showcase/src/app/layout.tsx
+++ b/packages/showcase/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -8,12 +9,12 @@ export const metadata: Metadata = {
 
 function NavLink({ href, children }: { href: string; children: React.ReactNode }) {
   return (
-    <a
+    <Link
       href={href}
       className="px-3 py-1.5 text-sm text-terminal-dim hover:text-terminal-text transition-colors rounded hover:bg-terminal-surface"
     >
       {children}
-    </a>
+    </Link>
   );
 }
 
@@ -24,13 +25,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <header className="border-b border-terminal-border bg-terminal-surface/50 backdrop-blur-sm sticky top-0 z-50">
           <div className="max-w-7xl mx-auto px-4 h-14 flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <a href="/" className="flex items-center gap-2">
+              <Link href="/" className="flex items-center gap-2">
                 <span className="text-lg font-bold text-terminal-text tracking-tight">YCLAW</span>
                 <span className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-terminal-red/10 border border-terminal-red/20">
                   <span className="w-2 h-2 rounded-full bg-terminal-red animate-live" />
                   <span className="text-xs font-medium text-terminal-red uppercase tracking-wider">Live</span>
                 </span>
-              </a>
+              </Link>
               <nav className="hidden sm:flex items-center gap-1 ml-4">
                 <NavLink href="/">Dashboard</NavLink>
                 <NavLink href="/agents">Agents</NavLink>


### PR DESCRIPTION
## Summary
Fix CI lint failure from PR #12 merge — ESLint `@next/next/no-html-link-for-pages` requires `<Link>` from `next/link` for internal navigation routes.

### Changes
- `NavLink` component: `<a>` → `<Link>`
- Logo link: `<a href="/">` → `<Link href="/">`
- External footer link (`yclaw.ai`): kept as `<a>` with `target="_blank"` (correct for external URLs)

## Test plan
- [x] Fixes the lint error from [run 24191207604](https://github.com/YClawAI/YClaw/actions/runs/24191207604/job/70608664389)

🤖 Generated with [Claude Code](https://claude.com/claude-code)