### PR TITLE
fix: add --dangerously-disable-package-manager-check to Core + compose Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY packages/memory/migrations packages/memory/migrations
 # Scope to core + its deps (memory). Without --filter, turbo would also try to
 # build mission-control (whose package.json is present for lockfile consistency
 # but whose source code is not in this context).
-RUN npx turbo build --filter=@yclaw/core...
+RUN npx turbo build --dangerously-disable-package-manager-check --filter=@yclaw/core...
 
 # --- Stage 3: Production runner ---
 FROM node:20-alpine AS runner

--- a/deploy/docker-compose/Dockerfile
+++ b/deploy/docker-compose/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts \
 COPY packages/core/src packages/core/src
 COPY packages/memory/src packages/memory/src
 COPY packages/memory/migrations packages/memory/migrations
-RUN npx turbo build --filter=@yclaw/core...
+RUN npx turbo build --dangerously-disable-package-manager-check --filter=@yclaw/core...
 
 # --- Stage 3: Production runner ---
 FROM node:20-slim AS runner


### PR DESCRIPTION
Missed two Dockerfiles in the previous turbo flag fix:
- `Dockerfile` (Core) — line 44
- `deploy/docker-compose/Dockerfile` — line 29

Same root cause: `packageManager` removed for Next.js 16 compat, Turborepo needs the flag to skip the check.

Needs `human-approved` label (Dockerfile is a build-critical file).