### PR TITLE
chore: trigger AO image rebuild

### DIFF
--- a/ao/agent-orchestrator.yaml
+++ b/ao/agent-orchestrator.yaml
@@ -1,3 +1,4 @@
+# Rebuilt: 2026-04-09 — trigger image update after go-live config fix
 # YClaw Agent Orchestrator Configuration
 # Managed by yclaw infra — do not edit on the container directly
 # ${AO_AUTH_TOKEN} is replaced by envsubst at container startup


### PR DESCRIPTION
AO is crash-looping because the deployed image (7a25c3b) predates the go-live config fix. The config on main already has `projects: {}` but the image was never rebuilt because no PRs touched `ao/` files.

This is a no-op comment change to trigger the `ao` change detection filter and force a fresh AO image build + deploy.

Needs `human-approved` label (touches ao/ config).