### PR TITLE
feat: install Claude Code plugins & skills in AO

### DIFF
--- a/ao/Dockerfile
+++ b/ao/Dockerfile
@@ -25,10 +25,30 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt-get update && apt-get install -y --no-install-recommends gh && rm -rf /var/lib/apt/lists/*
 
+# Python 3 — required by UI UX Pro Max design system generator (search.py)
+RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Coding harnesses
 RUN npm install -g @anthropic-ai/claude-code
 RUN npm install -g @mariozechner/pi-coding-agent
 RUN npm install -g @composio/ao@0.2.1
+
+# Claude Code plugins — installed at build time for --bare mode
+# 1. Add official Anthropic marketplace (superpowers lives here)
+# 2. Add anthropics/claude-code repo marketplace (frontend-design lives here)
+# 3. Install both plugins to user scope
+RUN claude plugins marketplace add anthropics/claude-plugins-official \
+    && claude plugins marketplace add anthropics/claude-code \
+        --sparse .claude-plugin plugins \
+    && claude plugins install superpowers@claude-plugins-official \
+    && claude plugins install frontend-design@claude-code-plugins
+
+# UI UX Pro Max — third-party design intelligence skill
+# Installs to ~/.claude/skills/ via the uipro CLI
+RUN npm install -g uipro-cli \
+    && mkdir -p /root/.claude/skills \
+    && cd /root && uipro init --ai claude --global
 
 # Codex CLI: pre-PR code review gate (multi-model ensemble)
 RUN npm install -g @openai/codex@0.118.0
@@ -52,6 +72,12 @@ RUN useradd -m -s /bin/bash -u 999 ao
 # Create workspace and persistent home directories
 RUN mkdir -p /data/worktrees /data/ao-state /data/ao-home /data/logs /app \
     && chown -R ao:ao /data /app /home/ao
+
+# Make Claude Code plugins/skills accessible to ao user
+RUN cp -r /root/.claude/plugins /home/ao/.claude/plugins 2>/dev/null || true \
+    && cp -r /root/.claude/skills /home/ao/.claude/skills 2>/dev/null || true \
+    && cp -r /root/.claude/settings.json /home/ao/.claude/settings.json 2>/dev/null || true \
+    && chown -R ao:ao /home/ao/.claude
 
 WORKDIR /app
 

--- a/ao/Dockerfile
+++ b/ao/Dockerfile
@@ -74,9 +74,10 @@ RUN mkdir -p /data/worktrees /data/ao-state /data/ao-home /data/logs /app \
     && chown -R ao:ao /data /app /home/ao
 
 # Make Claude Code plugins/skills accessible to ao user
-RUN cp -r /root/.claude/plugins /home/ao/.claude/plugins 2>/dev/null || true \
+RUN mkdir -p /home/ao/.claude \
+    && cp -r /root/.claude/plugins /home/ao/.claude/plugins 2>/dev/null || true \
     && cp -r /root/.claude/skills /home/ao/.claude/skills 2>/dev/null || true \
-    && cp -r /root/.claude/settings.json /home/ao/.claude/settings.json 2>/dev/null || true \
+    && cp /root/.claude/settings.json /home/ao/.claude/settings.json 2>/dev/null || true \
     && chown -R ao:ao /home/ao/.claude
 
 WORKDIR /app

--- a/ao/adapters/agent-claude-code-headless.mjs
+++ b/ao/adapters/agent-claude-code-headless.mjs
@@ -12,12 +12,25 @@ import { join } from 'node:path';
 /**
  * Resolve the latest installed version directory for a Claude Code plugin.
  * Plugin cache layout: basePath/<version>/ — returns the latest version path.
+ * Uses semver-aware sorting and filters out dotfiles/non-directories.
  */
 function resolvePluginDir(basePath) {
   try {
-    const versions = readdirSync(basePath);
+    const entries = readdirSync(basePath, { withFileTypes: true });
+    const versions = entries
+      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+      .map(e => e.name);
     if (versions.length > 0) {
-      versions.sort();
+      // Semver-aware sort: split on '.', compare each segment numerically
+      versions.sort((a, b) => {
+        const pa = a.split('.').map(Number);
+        const pb = b.split('.').map(Number);
+        for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+          const diff = (pa[i] || 0) - (pb[i] || 0);
+          if (diff !== 0) return diff;
+        }
+        return 0;
+      });
       return join(basePath, versions[versions.length - 1]);
     }
   } catch { /* plugin not installed */ }

--- a/ao/adapters/agent-claude-code-headless.mjs
+++ b/ao/adapters/agent-claude-code-headless.mjs
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
 
 /**
  * AO Agent Plugin: Claude Code (Headless one-shot)
@@ -7,6 +8,21 @@ import { readFileSync } from 'node:fs';
  * Each task is a separate subprocess. Context persists in the workspace.
  * For multi-turn (CI fixes, reviews): re-spawn with accumulated context.
  */
+
+/**
+ * Resolve the latest installed version directory for a Claude Code plugin.
+ * Plugin cache layout: basePath/<version>/ — returns the latest version path.
+ */
+function resolvePluginDir(basePath) {
+  try {
+    const versions = readdirSync(basePath);
+    if (versions.length > 0) {
+      versions.sort();
+      return join(basePath, versions[versions.length - 1]);
+    }
+  } catch { /* plugin not installed */ }
+  return null;
+}
 
 export const manifest = {
   name: 'claude-code-headless',
@@ -30,6 +46,16 @@ export function create() {
 
       // Permission bypass — required for autonomous operation
       parts.push('--dangerously-skip-permissions');
+
+      // ── Claude Code Plugins (loaded explicitly for --bare mode) ──────
+      // Superpowers: TDD, debugging methodology, brainstorming, code review
+      const superpowersDir = resolvePluginDir('/home/ao/.claude/plugins/cache/claude-plugins-official/superpowers');
+      if (superpowersDir) parts.push('--plugin-dir', superpowersDir);
+      // Frontend Design: Anthropic's official distinctive UI generation
+      const frontendDir = resolvePluginDir('/home/ao/.claude/plugins/cache/claude-code-plugins/frontend-design');
+      if (frontendDir) parts.push('--plugin-dir', frontendDir);
+      // Note: UI UX Pro Max is a skill (not a plugin) — auto-discovered
+      // from ~/.claude/skills/ via SKILL.md even in --bare mode.
 
       // Output format for structured parsing
       parts.push('--output-format', 'json');

--- a/ao/entrypoint.sh
+++ b/ao/entrypoint.sh
@@ -238,6 +238,15 @@ if [ -d /root/.config/gh ]; then
   chown -R ao:ao "$AO_HOME/.config/gh"
 fi
 
+# Preserve build-time Claude Code plugins on first boot
+if [ ! -d "$AO_HOME/.claude/plugins" ] && [ -d "/home/ao/.claude/plugins" ]; then
+  echo "[ao-entrypoint] Copying build-time Claude Code plugins to persistent home..."
+  mkdir -p "$AO_HOME/.claude"
+  cp -r /home/ao/.claude/plugins "$AO_HOME/.claude/plugins"
+  cp -r /home/ao/.claude/skills "$AO_HOME/.claude/skills" 2>/dev/null || true
+  cp /home/ao/.claude/settings.json "$AO_HOME/.claude/settings.json" 2>/dev/null || true
+fi
+
 # Symlink ao user's HOME directories to AO_HOME so Claude Code finds configs
 mkdir -p /home/ao/.config
 rm -rf /home/ao/.claude /home/ao/.config/gh 2>/dev/null || true

--- a/ao/entrypoint.sh
+++ b/ao/entrypoint.sh
@@ -238,13 +238,18 @@ if [ -d /root/.config/gh ]; then
   chown -R ao:ao "$AO_HOME/.config/gh"
 fi
 
-# Preserve build-time Claude Code plugins on first boot
+# Preserve build-time Claude Code plugins/skills on first boot (each checked independently)
+mkdir -p "$AO_HOME/.claude"
 if [ ! -d "$AO_HOME/.claude/plugins" ] && [ -d "/home/ao/.claude/plugins" ]; then
   echo "[ao-entrypoint] Copying build-time Claude Code plugins to persistent home..."
-  mkdir -p "$AO_HOME/.claude"
-  cp -r /home/ao/.claude/plugins "$AO_HOME/.claude/plugins"
-  cp -r /home/ao/.claude/skills "$AO_HOME/.claude/skills" 2>/dev/null || true
-  cp /home/ao/.claude/settings.json "$AO_HOME/.claude/settings.json" 2>/dev/null || true
+  cp -a /home/ao/.claude/plugins "$AO_HOME/.claude/plugins"
+fi
+if [ ! -d "$AO_HOME/.claude/skills" ] && [ -d "/home/ao/.claude/skills" ]; then
+  echo "[ao-entrypoint] Copying build-time Claude Code skills to persistent home..."
+  cp -a /home/ao/.claude/skills "$AO_HOME/.claude/skills"
+fi
+if [ ! -f "$AO_HOME/.claude/settings.json" ] && [ -f "/home/ao/.claude/settings.json" ]; then
+  cp /home/ao/.claude/settings.json "$AO_HOME/.claude/settings.json"
 fi
 
 # Symlink ao user's HOME directories to AO_HOME so Claude Code finds configs


### PR DESCRIPTION
## Summary
- Install **superpowers** (TDD, debugging, brainstorming, code review), **frontend-design** (distinctive UI generation), and **UI UX Pro Max** (161 design rules, 67 UI styles) into the AO Docker image
- Plugins loaded explicitly via `--plugin-dir` in `--bare` mode with dynamic version resolution (no hard-coded version paths)
- First-boot preservation copies build-time plugins to persistent EFS/EBS home so they survive container restarts

## Changes
| File | What |
|------|------|
| `ao/Dockerfile` | Add Python 3, marketplace setup, plugin installs, uipro skill, copy to ao user |
| `ao/adapters/agent-claude-code-headless.mjs` | Add `resolvePluginDir()` + `--plugin-dir` flags in `getLaunchCommand()` |
| `ao/entrypoint.sh` | First-boot plugin preservation before symlink to persistent home |

## Test plan
- [ ] Docker image builds successfully with all new `RUN` layers
- [ ] `claude plugins list` inside container shows superpowers + frontend-design
- [ ] `ls ~/.claude/skills/` shows UI UX Pro Max skill files
- [ ] Plugin files are owned by `ao` user (not root)
- [ ] First boot copies plugins to persistent volume; second boot skips copy
- [ ] Claude Code launched via headless adapter loads plugins (check logs for `--plugin-dir`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)