### PR TITLE
fix: remove invalid --global flag from uipro init

### DIFF
--- a/ao/Dockerfile
+++ b/ao/Dockerfile
@@ -48,7 +48,7 @@ RUN claude plugins marketplace add anthropics/claude-plugins-official \
 # Installs to ~/.claude/skills/ via the uipro CLI
 RUN npm install -g uipro-cli \
     && mkdir -p /root/.claude/skills \
-    && cd /root && uipro init --ai claude --global
+    && cd /root && uipro init --ai claude
 
 # Codex CLI: pre-PR code review gate (multi-model ensemble)
 RUN npm install -g @openai/codex@0.118.0


### PR DESCRIPTION
## Summary
- Docker build fails at step 9/26: `uipro init --ai claude --global` — `--global` is not a valid option
- `uipro-cli` installs to `.claude/skills/` by default, no `--global` flag needed

## Root cause
The prompt spec included `--global` but `uipro-cli` only supports `--ai`, `--force`, and `--offline` flags.

## Test plan
- [ ] Docker image builds past the uipro step
- [ ] `.claude/skills/ui-ux-pro-max/` directory exists in the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)