### PR TITLE
fix: MC deploy failure — skip Next.js 16 lockfile patcher in Docker

### DIFF
--- a/packages/mission-control/Dockerfile
+++ b/packages/mission-control/Dockerfile
@@ -33,6 +33,11 @@ COPY packages/mission-control/ packages/mission-control/
 RUN cp -r /app/node_modules/@yclaw/core/node_modules ./packages/core/node_modules 2>/dev/null || true
 
 ENV NEXT_TELEMETRY_DISABLED=1
+# Next.js 16 lockfile patcher misparses monorepo package-lock.json and tells
+# you to re-run "npm install" — which never happens inside Docker. The patched
+# lockfile is incomplete, leaving SWC binaries in a cache dir instead of
+# node_modules. Skip the patcher entirely; npm ci already installed everything.
+ENV NEXT_PRIVATE_SKIP_LOCKFILE_PATCH=1
 
 # Turbo handles the build DAG (memory → core → mission-control) in parallel.
 # Replaces 3 sequential `npm run build --workspace=` commands.

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", ".next/**"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary
- Fixes Mission Control ECS deployment failure (`ServicesStable waiter failed: Max attempts exceeded`)
- Root cause: Next.js 16 lockfile patcher runs during `next build` inside Docker, patches the lockfile, then says "please run `npm install`" — which never happens inside the Docker build
- This leaves SWC binaries in `/root/.cache/next-swc` instead of `node_modules`, producing an incomplete standalone output
- The container starts but fails health checks, ECS cycles tasks for 10 minutes, then gives up

## Changes
- **`packages/mission-control/Dockerfile`**: Set `NEXT_PRIVATE_SKIP_LOCKFILE_PATCH=1` in builder stage — `npm ci` already installed all deps correctly, the patcher just corrupts things
- **`turbo.json`**: Add `.next/**` to build outputs — Next.js outputs to `.next/`, not `dist/`, so turbo was warning "no output files found for task"

## Evidence from failed run
```
⚠ Found lockfile missing swc dependencies, patching...
  Downloading swc package @next/swc-linux-x64-gnu... to /root/.cache/next-swc
⚠ Lockfile was successfully patched, please run "npm install" to ensure @next/swc dependencies are downloaded
```
```
WARNING  no output files found for task @yclaw/mission-control#build
```

## Test plan
- [x] TypeScript compilation passes
- [ ] Merge and verify MC deploy workflow succeeds
- [ ] Verify `agents.yclaw.ai` loads MC dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)