### PR TITLE
fix: remove all Slack references — YCLAW is Discord-only

### DIFF
--- a/departments/development/architect.yaml
+++ b/departments/development/architect.yaml
@@ -122,8 +122,6 @@ actions:
   - vault:read
   - vault:search
   - vault:write
-  - slack:message
-  - slack:thread_reply
   - discord:message
   - discord:thread_reply
   - discord:react

--- a/departments/development/designer.yaml
+++ b/departments/development/designer.yaml
@@ -55,8 +55,6 @@ actions:
   - github:create_issue
   - github:pr_comment
   - github:pr_review
-  - slack:message
-  - slack:thread_reply
   - discord:message
   - discord:thread_reply
   - discord:react

--- a/departments/executive/reviewer.yaml
+++ b/departments/executive/reviewer.yaml
@@ -45,9 +45,6 @@ triggers:
 actions:
 - github:get_contents
 - x:search
-- slack:message
-- slack:thread_reply
-- slack:alert
 - discord:message
 - discord:thread_reply
 - discord:react

--- a/departments/executive/strategist.yaml
+++ b/departments/executive/strategist.yaml
@@ -68,9 +68,6 @@ triggers:
   task: reconcile_pipeline
   description: "Run PR/Issue reconciliation loop"
 - type: event
-  event: slack:app_mention
-  task: handle_slack_request
-- type: event
   event: claudeception:reflect
   task: self_reflection
   model:
@@ -106,8 +103,6 @@ actions:
 - telegram:announce
 - telegram:set_title
 - telegram:set_description
-- slack:message
-- slack:thread_reply
 - discord:message
 - discord:thread_reply
 - discord:react
@@ -120,7 +115,6 @@ data_sources: []
 event_subscriptions:
 - claudeception:reflect
 - standup:report
-- slack:app_mention
 - deploy:approved
 event_publications:
 - strategist:weekly_directive

--- a/departments/finance/treasurer.yaml
+++ b/departments/finance/treasurer.yaml
@@ -41,9 +41,6 @@ actions:
   - github:commit_file
   - github:get_contents
   - github:create_branch
-  - slack:message
-  - slack:thread_reply
-  - slack:alert
   - discord:message
   - discord:thread_reply
   - discord:react

--- a/departments/marketing/ember.yaml
+++ b/departments/marketing/ember.yaml
@@ -81,8 +81,6 @@ actions:
   - x:user_tweets
   - telegram:message
   - telegram:announce
-  - slack:message
-  - slack:thread_reply
   - discord:get_channel_history
   - event:publish
 

--- a/departments/marketing/forge.yaml
+++ b/departments/marketing/forge.yaml
@@ -50,8 +50,6 @@ actions:
   - twitter:update_profile_image
   - twitter:update_profile_banner
   - telegram:set_chat_photo
-  - slack:message
-  - slack:thread_reply
   - discord:message
   - discord:thread_reply
   - discord:react

--- a/departments/marketing/scout.yaml
+++ b/departments/marketing/scout.yaml
@@ -63,8 +63,6 @@ actions:
   - x:user_tweets
   - twitter:read_metrics
   - email:send
-  - slack:message
-  - slack:thread_reply
   - discord:get_channel_history
   - event:publish
 

--- a/departments/operations/librarian.yaml
+++ b/departments/operations/librarian.yaml
@@ -41,8 +41,6 @@ actions:
   - vault:graph_query
   - github:commit_file
   - github:get_contents
-  - slack:message
-  - slack:thread_reply
   - discord:message
   - discord:thread_reply
   - discord:react

--- a/departments/operations/sentinel.yaml
+++ b/departments/operations/sentinel.yaml
@@ -58,9 +58,6 @@ actions:
   - github:get_contents
   - github:get_diff
   - repo:list
-  - slack:message
-  - slack:alert
-  - slack:thread_reply
   - discord:message
   - discord:thread_reply
   - discord:get_channel_history

--- a/departments/support/guide.yaml
+++ b/departments/support/guide.yaml
@@ -48,8 +48,6 @@ actions:
   - github:get_contents
   - vault:read
   - vault:search
-  - slack:message
-  - slack:thread_reply
   - discord:message
   - discord:thread_reply
   - discord:get_thread

--- a/departments/support/keeper.yaml
+++ b/departments/support/keeper.yaml
@@ -62,9 +62,8 @@ actions:
   - telegram:ban
   - telegram:restrict
   - telegram:set_permissions
-  - slack:message
-  - slack:alert
   - discord:message
+  - discord:alert
   - discord:thread_reply
   - discord:create_thread
   - discord:get_channel_history

--- a/deploy/aws/modules/compute/main.tf
+++ b/deploy/aws/modules/compute/main.tf
@@ -250,6 +250,16 @@ resource "aws_ecs_task_definition" "core" {
       { name = "YCLAW_S3_BUCKET", value = var.s3_bucket },
       { name = "AWS_REGION", value = var.aws_region },
       { name = "REDIS_URL", value = var.redis_url },
+      # Discord channel routing — agents are Discord-only
+      { name = "DISCORD_CHANNEL_GENERAL", value = var.discord_channel_general },
+      { name = "DISCORD_CHANNEL_EXECUTIVE", value = var.discord_channel_executive },
+      { name = "DISCORD_CHANNEL_DEVELOPMENT", value = var.discord_channel_development },
+      { name = "DISCORD_CHANNEL_MARKETING", value = var.discord_channel_marketing },
+      { name = "DISCORD_CHANNEL_OPERATIONS", value = var.discord_channel_operations },
+      { name = "DISCORD_CHANNEL_FINANCE", value = var.discord_channel_finance },
+      { name = "DISCORD_CHANNEL_SUPPORT", value = var.discord_channel_support },
+      { name = "DISCORD_CHANNEL_AUDIT", value = var.discord_channel_audit },
+      { name = "DISCORD_CHANNEL_ALERTS", value = var.discord_channel_alerts },
     ]
 
     # Sensitive values injected from Secrets Manager by ARN

--- a/deploy/aws/modules/compute/variables.tf
+++ b/deploy/aws/modules/compute/variables.tf
@@ -79,6 +79,55 @@ variable "s3_bucket" {
   type = string
 }
 
+# ─── Discord channel routing ──────────────────────────────────────────────────
+# YCLAW is Discord-only. These channel IDs are injected into the core container
+# for agent notification routing via channel-routing.ts.
+
+variable "discord_channel_general" {
+  type    = string
+  default = ""
+}
+
+variable "discord_channel_executive" {
+  type    = string
+  default = ""
+}
+
+variable "discord_channel_development" {
+  type    = string
+  default = ""
+}
+
+variable "discord_channel_marketing" {
+  type    = string
+  default = ""
+}
+
+variable "discord_channel_operations" {
+  type    = string
+  default = ""
+}
+
+variable "discord_channel_finance" {
+  type    = string
+  default = ""
+}
+
+variable "discord_channel_support" {
+  type    = string
+  default = ""
+}
+
+variable "discord_channel_audit" {
+  type    = string
+  default = ""
+}
+
+variable "discord_channel_alerts" {
+  type    = string
+  default = ""
+}
+
 variable "secret_arns" {
   type        = map(string)
   description = "Map of env var name → Secrets Manager ARN"

--- a/packages/core/src/reactions/manager.ts
+++ b/packages/core/src/reactions/manager.ts
@@ -77,8 +77,8 @@ export interface ReactionsManagerDeps {
   publishEvent: (source: string, type: string, data: Record<string, unknown>, correlationId?: string) => Promise<void>;
   /** Callback to execute a GitHub action (merge_pr, close_issue, etc.). */
   executeGitHubAction: (action: string, params: Record<string, unknown>) => Promise<{ success: boolean; error?: string }>;
-  /** Callback to execute a Slack action. */
-  executeSlackAction: (channel: string, text: string) => Promise<void>;
+  /** Callback to execute a Discord notification action. */
+  executeDiscordAction?: (channel: string, text: string) => Promise<void>;
   /** Callback to create/update a task in the Task Registry. */
   executeTaskAction: (action: string, params: Record<string, unknown>) => Promise<void>;
   /** Optional: custom rules (overrides defaults). */
@@ -445,11 +445,11 @@ export class ReactionsManager {
         break;
       }
 
-      case 'slack:message': {
+      case 'discord:message': {
         const channel = params.channel as string;
         const text = params.text as string;
-        if (!channel || !text) throw new Error('slack:message requires channel and text');
-        await this.deps.executeSlackAction(channel, text);
+        if (!channel || !text) throw new Error('discord:message requires channel and text');
+        await this.deps.executeDiscordAction?.(channel, text);
         break;
       }
 

--- a/packages/core/src/reactions/manager.ts
+++ b/packages/core/src/reactions/manager.ts
@@ -449,7 +449,13 @@ export class ReactionsManager {
         const channel = params.channel as string;
         const text = params.text as string;
         if (!channel || !text) throw new Error('discord:message requires channel and text');
-        await this.deps.executeDiscordAction?.(channel, text);
+        if (!this.deps.executeDiscordAction) {
+          logger.warn('discord:message action skipped — executeDiscordAction not wired', {
+            channel,
+          });
+          break;
+        }
+        await this.deps.executeDiscordAction(channel, text);
         break;
       }
 

--- a/packages/core/src/reactions/rules.ts
+++ b/packages/core/src/reactions/rules.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ReactionRule } from './types.js';
+import { getChannelForDepartment } from '../utils/channel-routing.js';
 
 /**
  * GitHub login(s) authorized for comment-based PR approval.
@@ -41,9 +42,9 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
     escalation: {
       afterMs: 30 * 60 * 1000, // 30 minutes
       action: {
-        type: 'slack:message',
+        type: 'discord:message',
         params: {
-          channel: 'C0000000007', // #yclaw-alerts
+          channel: getChannelForDepartment('alerts', 'discord') ?? '',
           text: '🚨 CI stuck on branch {{branch}} after 2 retries. Workflow: {{workflow}}. Needs human attention: {{url}}',
         },
       },
@@ -74,9 +75,9 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
     escalation: {
       afterMs: 30 * 60 * 1000,
       action: {
-        type: 'slack:message',
+        type: 'discord:message',
         params: {
-          channel: 'C0000000007',
+          channel: getChannelForDepartment('alerts', 'discord') ?? '',
           text: '🚨 Review comments unaddressed on PR #{{pr_number}} for 30+ minutes. Reviewer: {{reviewer}}. {{pr_url}}',
         },
       },
@@ -110,9 +111,9 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
         params: {},
       },
       {
-        type: 'slack:message',
+        type: 'discord:message',
         params: {
-          channel: 'C0000000002', // #yclaw-development
+          channel: getChannelForDepartment('development', 'discord') ?? '',
           text: '🔄 Auto-updating PR #{{pr_number}} branch — was behind master. CI will re-run.',
         },
       },
@@ -156,9 +157,9 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
         params: { stage: 'merged', status: 'completed' },
       },
       {
-        type: 'slack:message',
+        type: 'discord:message',
         params: {
-          channel: 'C0000000002', // #yclaw-development
+          channel: getChannelForDepartment('development', 'discord') ?? '',
           text: '✅ Auto-merged PR #{{pr_number}} ({{head_branch}}) — reviewed by {{reviewer}}',
         },
       },
@@ -197,9 +198,9 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
         params: { stage: 'merged', status: 'completed' },
       },
       {
-        type: 'slack:message',
+        type: 'discord:message',
         params: {
-          channel: 'C0000000002',
+          channel: getChannelForDepartment('development', 'discord') ?? '',
           text: '✅ Auto-merged PR #{{pr_number}} after approval by {{reviewer}}',
         },
       },
@@ -271,9 +272,9 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
         params: { stage: 'merged', status: 'completed' },
       },
       {
-        type: 'slack:message',
+        type: 'discord:message',
         params: {
-          channel: 'C0000000002', // #yclaw-development
+          channel: getChannelForDepartment('development', 'discord') ?? '',
           text: '✅ Auto-merged PR #{{pr_number}} — Architect comment [APPROVED], CI was green',
         },
       },
@@ -362,9 +363,9 @@ export const DEFAULT_REACTION_RULES: ReactionRule[] = [
         },
       },
       {
-        type: 'slack:message',
+        type: 'discord:message',
         params: {
-          channel: 'C0000000002',
+          channel: getChannelForDepartment('development', 'discord') ?? '',
           text: '🔄 Stale review detected on PR #{{pr_number}} — requesting Architect re-review after new commits.',
         },
       },

--- a/packages/core/src/reactions/types.ts
+++ b/packages/core/src/reactions/types.ts
@@ -70,7 +70,7 @@ export interface ReactionAction {
     | 'task:update'
     | 'task:create'
     | 'event:publish'
-    | 'slack:message'
+    | 'discord:message'
     | 'github:update_branch';
   params: Record<string, unknown>;
 }

--- a/packages/core/tests/reactions-types.test.ts
+++ b/packages/core/tests/reactions-types.test.ts
@@ -49,7 +49,7 @@ describe('DEFAULT_REACTION_RULES', () => {
       'task:update',
       'task:create',
       'event:publish',
-      'slack:message',
+      'discord:message',
       'github:update_branch',
     ]);
 

--- a/packages/core/tests/reactions.test.ts
+++ b/packages/core/tests/reactions.test.ts
@@ -61,7 +61,7 @@ function createMockDeps(redis: any) {
     triggerAgent: vi.fn(async () => {}),
     publishEvent: vi.fn(async () => {}),
     executeGitHubAction: vi.fn(async () => ({ success: true })),
-    executeSlackAction: vi.fn(async () => {}),
+    executeDiscordAction: vi.fn(async () => {}),
     executeTaskAction: vi.fn(async () => {}),
   };
 }
@@ -109,7 +109,7 @@ describe('ReactionsManager', () => {
         id: 'test-approved',
         enabled: true,
         trigger: { event: 'github:pr_review_submitted', filter: { review_state: 'approved' } },
-        actions: [{ type: 'slack:message', params: { channel: 'C123', text: 'Approved!' } }],
+        actions: [{ type: 'discord:message', params: { channel: 'C123', text: 'Approved!' } }],
       }];
 
       manager = new ReactionsManager({ ...deps, rules });
@@ -120,7 +120,7 @@ describe('ReactionsManager', () => {
         review_state: 'changes_requested',
         pr_number: 42,
       });
-      expect(deps.executeSlackAction).not.toHaveBeenCalled();
+      expect(deps.executeDiscordAction).not.toHaveBeenCalled();
 
       // Should match
       await manager.handleEvent('github:pr_review_submitted', {
@@ -128,7 +128,7 @@ describe('ReactionsManager', () => {
         review_state: 'approved',
         pr_number: 42,
       });
-      expect(deps.executeSlackAction).toHaveBeenCalledWith('C123', 'Approved!');
+      expect(deps.executeDiscordAction).toHaveBeenCalledWith('C123', 'Approved!');
     });
 
     it('should skip disabled rules', async () => {


### PR DESCRIPTION
## Summary
- YCLAW has no Slack workspace — every `slack:*` action fails silently with "Slack client not initialized: missing SLACK_BOT_TOKEN", making agents appear dead
- Removes all Slack action references from 12 agent YAMLs and 7 reaction rules
- Replaces `slack:message` in reaction rules with `discord:message` using `getChannelForDepartment()` (single source of truth, no hardcoded channel IDs)
- Adds `discord:alert` to Keeper (was the only agent missing the Discord equivalent of `slack:alert`)
- Adds Discord channel env vars to Terraform for durable ECS injection

## Changes (19 files)

**Agent YAMLs (12 files):**
All `slack:message`, `slack:thread_reply`, `slack:alert` removed from action lists. `slack:app_mention` trigger + event_subscription removed from Strategist. `discord:alert` added to Keeper.

**Reaction rules + types (3 files):**
- `rules.ts`: 7× `slack:message` → `discord:message` with `getChannelForDepartment()` routing
- `types.ts`: `ReactionAction.type` union updated
- `manager.ts`: `executeSlackAction` → `executeDiscordAction` (optional dep)

**Terraform (2 files):**
- `main.tf`: 9 `DISCORD_CHANNEL_*` env vars added to core container
- `variables.tf`: 9 corresponding variable declarations

**Tests (2 files):** Updated to match new `discord:message` action type

## Protected paths
`departments/**` is convention-protected — requires Architect review per CLAUDE.md.

## Test plan
- [x] Zero `slack:` references remain in any agent YAML
- [x] All 7 `slack:message` in rules.ts replaced with `discord:message`
- [x] TypeScript compilation passes
- [x] All 1672 tests pass (95 test files)
- [ ] After deploy: agent notifications appear in Discord channels
- [ ] After deploy: `docker logs` shows zero "Slack client not initialized" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)