### PR TITLE
fix: Showcase ECR permissions + MC health check path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -375,6 +375,34 @@ jobs:
           docker push ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
           docker push ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
 
+      - name: Ensure ALB health check targets /api/health
+        run: |
+          # PR #28 added auth middleware that redirects unauthenticated requests
+          # on non-public paths (including /) with 307. The ALB health check must
+          # hit /api/health which is excluded from auth in middleware.ts.
+          TG_ARN=$(aws elbv2 describe-target-groups \
+            --region $AWS_REGION \
+            --query "TargetGroups[?TargetGroupName=='yclaw-mc-tg'].TargetGroupArn | [0]" \
+            --output text 2>/dev/null || true)
+          if [ -n "$TG_ARN" ] && [ "$TG_ARN" != "None" ] && [ "$TG_ARN" != "null" ]; then
+            CURRENT_PATH=$(aws elbv2 describe-target-groups \
+              --target-group-arns "$TG_ARN" \
+              --region $AWS_REGION \
+              --query 'TargetGroups[0].HealthCheckPath' \
+              --output text)
+            if [ "$CURRENT_PATH" != "/api/health" ]; then
+              echo "Updating health check path from '$CURRENT_PATH' to '/api/health'"
+              aws elbv2 modify-target-group \
+                --target-group-arn "$TG_ARN" \
+                --health-check-path "/api/health" \
+                --region $AWS_REGION
+            else
+              echo "Health check path already correct: /api/health"
+            fi
+          else
+            echo "::warning::Could not find target group yclaw-mc-tg"
+          fi
+
       - name: Register new task definition and deploy
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/terraform/github-oidc.tf
+++ b/terraform/github-oidc.tf
@@ -54,6 +54,12 @@ resource "aws_iam_role" "github_actions_deploy" {
 }
 
 # ─── ECR Permissions (push images) ──────────────────────────────────────────
+#
+# The deploy workflow pushes to multiple ECR repos (yclaw-agents,
+# yclaw-mission-control, yclaw-ao, yclaw-showcase). Use a wildcard ARN
+# so new services don't require a Terraform change to deploy.
+
+data "aws_caller_identity" "current" {}
 
 resource "aws_iam_role_policy" "github_ecr" {
   name = "ecr-push"
@@ -82,13 +88,18 @@ resource "aws_iam_role_policy" "github_ecr" {
           "ecr:DescribeImageScanFindings",
           "ecr:DescribeImages"
         ]
-        Resource = [aws_ecr_repository.agents.arn]
+        Resource = [
+          "arn:aws:ecr:${var.aws_region}:${data.aws_caller_identity.current.account_id}:repository/yclaw-*"
+        ]
       }
     ]
   })
 }
 
 # ─── ECS Permissions (deploy service) ───────────────────────────────────────
+#
+# The deploy workflow updates multiple ECS services (core, MC, AO, showcase).
+# Scope UpdateService to any service in the cluster rather than a single service.
 
 resource "aws_iam_role_policy" "github_ecs" {
   name = "ecs-deploy"
@@ -113,7 +124,7 @@ resource "aws_iam_role_policy" "github_ecs" {
           "ecs:UpdateService",
           "ecs:DescribeServices"
         ]
-        Resource = [aws_ecs_service.agents.id]
+        Resource = ["arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:service/${aws_ecs_cluster.yclaw.name}/*"]
       },
       {
         Sid    = "PassRole"
@@ -138,6 +149,16 @@ resource "aws_iam_role_policy" "github_ecs" {
             "ecs:cluster" = aws_ecs_cluster.yclaw.arn
           }
         }
+      },
+      {
+        Sid    = "HealthCheckFix"
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:DescribeTargetHealth"
+        ]
+        Resource = ["*"]
       }
     ]
   })


### PR DESCRIPTION
## Summary

Fixes both deploy failures from the [CI run](https://github.com/YClawAI/YClaw/actions/runs/24243919543) after PR #28 merge:

- **Deploy Showcase** — IAM `ecr-push` policy only covered the `yclaw` ECR repo. Showcase pushes to `yclaw-showcase` which wasn't authorized. Widened to `yclaw-*` wildcard ARN so all current and future service repos are covered.
- **Deploy Mission Control** — ALB health check targets `/`, but PR #28's auth middleware now redirects unauthenticated requests with 307. ALB expects 200 → tasks killed → service never stabilizes. Added a deploy step that updates the health check path to `/api/health` (already excluded from auth in `middleware.ts`).

Also fixed two latent issues:
- ECS `UpdateService` permission was scoped to the agents service only — widened to all services in the cluster
- Added ELBv2 permissions for the health check path management

## Test plan

- [ ] Merge and verify `Deploy Showcase` job passes ECR push step
- [ ] Verify `Deploy Mission Control` job updates health check path and service stabilizes
- [ ] Run `terraform plan` to confirm IAM policy changes are clean (no unexpected drift)
- [ ] After deploy, verify MC health endpoint returns 200: `curl -s -o /dev/null -w '%{http_code}' <MC_URL>/api/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)