### PR TITLE
fix: MC health check — optional deps don't fail ALB

### DIFF
--- a/packages/mission-control/src/app/api/health/route.ts
+++ b/packages/mission-control/src/app/api/health/route.ts
@@ -88,6 +88,11 @@ export async function GET() {
   }
 
   // ── Aggregate ────────────────────────────────────────────────────
+  // Core deps (mongodb, redis) must be up for a healthy ALB response.
+  // Optional deps (gateway, operators) can be down without failing the
+  // health check — they degrade functionality but the app still serves.
+  const CORE_DEPS = new Set(['mongodb', 'redis']);
+  const coreDown = checks.some((c) => CORE_DEPS.has(c.name) && c.status === 'down');
   const hasDown = checks.some((c) => c.status === 'down');
   const hasDegraded = checks.some((c) => c.status === 'degraded');
 
@@ -97,7 +102,7 @@ export async function GET() {
       ? 'degraded'
       : 'ok';
 
-  const httpStatus = overallStatus === 'ok' ? 200 : 503;
+  const httpStatus = coreDown ? 503 : 200;
 
   return NextResponse.json({ status: overallStatus, checks }, { status: httpStatus });
 }

--- a/packages/mission-control/src/lib/gateway-ws.ts
+++ b/packages/mission-control/src/lib/gateway-ws.ts
@@ -123,6 +123,8 @@ class GatewayClient {
       this.resolveReady = resolve;
       this.rejectReady = reject;
     });
+    // Prevent unhandled rejection when gateway token is not configured
+    this.ready.catch(() => {});
 
     // Wire state cache updates
     this.on('status', (payload) => {


### PR DESCRIPTION
## Summary

Follow-up to PR #29. After fixing the health check path from `/` to `/api/health`, the endpoint still returns 503 because:

- `OPENCLAW_GATEWAY_TOKEN` is not in the MC task definition
- The gateway client rejects its `ready` promise → unhandled rejection
- `/api/health` marks gateway as "down" → overall status "down" → HTTP 503
- ALB kills the task even though MongoDB and Redis are healthy

**Fixes:**
- Health endpoint only returns 503 when **core deps** (mongodb, redis) are down. Optional deps (gateway, operators) still report status in the JSON body for monitoring but don't fail the HTTP response
- Gateway WS client catches the `ready` promise rejection to prevent `unhandledRejection` crash when token isn't configured

## Test plan

- [ ] Merge and verify MC deployment stabilizes (ALB health check returns 200)
- [ ] Verify `/api/health` JSON body still shows gateway status for monitoring dashboards
- [ ] Confirm no `unhandledRejection` errors in CloudWatch logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)