### PR TITLE
fix: restore autonomous agent operation — 5 blockers

### DIFF
--- a/departments/development/designer.yaml
+++ b/departments/development/designer.yaml
@@ -77,6 +77,8 @@ actions:
   - stitch:list_screens
 
 data_sources:
+  # Requires a github_repo fetcher to be registered for this data source to resolve.
+  # Designer can also load design references on-demand via github:get_contents.
   - type: github_repo
     name: style-guide
     repo: your-org/STYLE-GUIDE
@@ -85,6 +87,7 @@ data_sources:
 event_subscriptions:
   - claudeception:reflect
   - ao:pr_ready
+  - forge:asset_ready
   - strategist:designer_directive
   - strategist:design_generate
   - architect:design_directive

--- a/departments/executive/strategist.yaml
+++ b/departments/executive/strategist.yaml
@@ -75,6 +75,38 @@ triggers:
     model: claude-sonnet-4-20250514
     temperature: 0.5
     maxTokens: 4096
+- type: event
+  event: sentinel:alert
+  task: handle_system_alert
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-20250514
+    temperature: 0.3
+    maxTokens: 4096
+- type: event
+  event: ao:task_failed
+  task: handle_ao_failure
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-20250514
+    temperature: 0.3
+    maxTokens: 4096
+- type: event
+  event: ao:spawn_failed
+  task: handle_ao_failure
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-20250514
+    temperature: 0.3
+    maxTokens: 4096
+- type: event
+  event: architect:task_blocked
+  task: handle_blocked_task
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-20250514
+    temperature: 0.3
+    maxTokens: 4096
 # Deploy Governance v2: execute approved CRITICAL-tier deployments
 - type: event
   event: deploy:approved
@@ -116,6 +148,10 @@ event_subscriptions:
 - claudeception:reflect
 - standup:report
 - deploy:approved
+- sentinel:alert
+- ao:task_failed
+- ao:spawn_failed
+- architect:task_blocked
 event_publications:
 - strategist:weekly_directive
 - strategist:midweek_adjustment

--- a/departments/executive/strategist.yaml
+++ b/departments/executive/strategist.yaml
@@ -8,165 +8,165 @@ model:
   temperature: 0.7
   maxTokens: 8192
 system_prompts:
-- claudeception.md
-- skill-usage.md
-- mission_statement.md
-- chain-of-command.md
-- daily-standup.md
-- executive-directive.md
-- protocol-overview.md
-- model-review.md
-- strategist-workflow.md
-- strategist-heartbeat.md
-- strategist-objectives.md
-triggers:
-- type: cron
-  schedule: 45 13 * * *
-  task: standup_synthesis
-  model:
-    provider: anthropic
-    model: claude-sonnet-4-20250514
-    temperature: 0.3
-    maxTokens: 4096
-- type: cron
-  schedule: 0 14 * * 1
-  task: weekly_directive
-- type: cron
-  schedule: 0 14 * * 3
-  task: midweek_review
-- type: cron
-  schedule: 0 7 1 * *
-  task: monthly_strategy
-- type: cron
-  schedule: 0 14 1-7 * 1
-  task: model_review
-- type: cron
-  schedule: '*/30 * * * *'
-  task: heartbeat
-  model:
-    provider: anthropic
-    model: claude-sonnet-4-20250514
-    temperature: 0.3
-    maxTokens: 4096
-  prompts:
-  - strategist-heartbeat.md
-  - executive-directive.md
+  - claudeception.md
+  - skill-usage.md
+  - mission_statement.md
   - chain-of-command.md
-- type: batch_event
-  events:
-  - standup:report
-  min_count: 10
-  timeout_ms: 1800000
-  task: standup_synthesis
-  model:
-    provider: anthropic
-    model: claude-opus-4-6
-    temperature: 0.5
-    maxTokens: 8192
-- type: cron
-  schedule: '*/10 * * * *'
-  task: reconcile_pipeline
-  description: "Run PR/Issue reconciliation loop"
-- type: event
-  event: claudeception:reflect
-  task: self_reflection
-  model:
-    provider: anthropic
-    model: claude-sonnet-4-20250514
-    temperature: 0.5
-    maxTokens: 4096
-- type: event
-  event: sentinel:alert
-  task: handle_system_alert
-  model:
-    provider: anthropic
-    model: claude-sonnet-4-20250514
-    temperature: 0.3
-    maxTokens: 4096
-- type: event
-  event: ao:task_failed
-  task: handle_ao_failure
-  model:
-    provider: anthropic
-    model: claude-sonnet-4-20250514
-    temperature: 0.3
-    maxTokens: 4096
-- type: event
-  event: ao:spawn_failed
-  task: handle_ao_failure
-  model:
-    provider: anthropic
-    model: claude-sonnet-4-20250514
-    temperature: 0.3
-    maxTokens: 4096
-- type: event
-  event: architect:task_blocked
-  task: handle_blocked_task
-  model:
-    provider: anthropic
-    model: claude-sonnet-4-20250514
-    temperature: 0.3
-    maxTokens: 4096
-# Deploy Governance v2: execute approved CRITICAL-tier deployments
-- type: event
-  event: deploy:approved
-  task: execute_approved_deploy
-  model:
-    provider: anthropic
-    model: claude-sonnet-4-20250514
-    temperature: 0.2
-    maxTokens: 4096
+  - daily-standup.md
+  - executive-directive.md
+  - protocol-overview.md
+  - model-review.md
+  - strategist-workflow.md
+  - strategist-heartbeat.md
+  - strategist-objectives.md
+triggers:
+  - type: cron
+    schedule: 45 13 * * *
+    task: standup_synthesis
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      temperature: 0.3
+      maxTokens: 4096
+  - type: cron
+    schedule: 0 14 * * 1
+    task: weekly_directive
+  - type: cron
+    schedule: 0 14 * * 3
+    task: midweek_review
+  - type: cron
+    schedule: 0 7 1 * *
+    task: monthly_strategy
+  - type: cron
+    schedule: 0 14 1-7 * 1
+    task: model_review
+  - type: cron
+    schedule: '*/30 * * * *'
+    task: heartbeat
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      temperature: 0.3
+      maxTokens: 4096
+    prompts:
+      - strategist-heartbeat.md
+      - executive-directive.md
+      - chain-of-command.md
+  - type: batch_event
+    events:
+      - standup:report
+    min_count: 10
+    timeout_ms: 1800000
+    task: standup_synthesis
+    model:
+      provider: anthropic
+      model: claude-opus-4-6
+      temperature: 0.5
+      maxTokens: 8192
+  - type: cron
+    schedule: '*/10 * * * *'
+    task: reconcile_pipeline
+    description: "Run PR/Issue reconciliation loop"
+  - type: event
+    event: claudeception:reflect
+    task: self_reflection
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      temperature: 0.5
+      maxTokens: 4096
+  - type: event
+    event: sentinel:alert
+    task: handle_system_alert
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      temperature: 0.3
+      maxTokens: 4096
+  - type: event
+    event: ao:task_failed
+    task: handle_ao_failure
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      temperature: 0.3
+      maxTokens: 4096
+  - type: event
+    event: ao:spawn_failed
+    task: handle_ao_failure
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      temperature: 0.3
+      maxTokens: 4096
+  - type: event
+    event: architect:task_blocked
+    task: handle_blocked_task
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      temperature: 0.3
+      maxTokens: 4096
+  # Deploy Governance v2: execute approved CRITICAL-tier deployments
+  - type: event
+    event: deploy:approved
+    task: execute_approved_deploy
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      temperature: 0.2
+      maxTokens: 4096
 actions:
-- github:commit_file
-- github:get_contents
-- github:create_branch
-- github:get_diff
-- vault:read
-- vault:search
-- github:pr_review
-- github:pr_comment
-- github:get_issue
-- github:list_issues
-- twitter:update_profile
-- twitter:update_profile_image
-- twitter:update_profile_banner
-- x:search
-- x:user
-- telegram:announce
-- telegram:set_title
-- telegram:set_description
-- discord:message
-- discord:thread_reply
-- discord:react
-- event:publish
-- deploy:assess
-- deploy:execute
-- task:query
-- task:summary
+  - github:commit_file
+  - github:get_contents
+  - github:create_branch
+  - github:get_diff
+  - vault:read
+  - vault:search
+  - github:pr_review
+  - github:pr_comment
+  - github:get_issue
+  - github:list_issues
+  - twitter:update_profile
+  - twitter:update_profile_image
+  - twitter:update_profile_banner
+  - x:search
+  - x:user
+  - telegram:announce
+  - telegram:set_title
+  - telegram:set_description
+  - discord:message
+  - discord:thread_reply
+  - discord:react
+  - event:publish
+  - deploy:assess
+  - deploy:execute
+  - task:query
+  - task:summary
 data_sources: []
 event_subscriptions:
-- claudeception:reflect
-- standup:report
-- deploy:approved
-- sentinel:alert
-- ao:task_failed
-- ao:spawn_failed
-- architect:task_blocked
+  - claudeception:reflect
+  - standup:report
+  - deploy:approved
+  - sentinel:alert
+  - ao:task_failed
+  - ao:spawn_failed
+  - architect:task_blocked
 event_publications:
-- strategist:weekly_directive
-- strategist:midweek_adjustment
-- strategist:architect_directive
-- strategist:builder_directive
-- strategist:deployer_directive
-- strategist:designer_directive
-- strategist:design_generate
-- strategist:standup_synthesis
-- strategist:sentinel_directive
-- strategist:keeper_directive
-- strategist:ember_directive
-- strategist:forge_directive
-- strategist:scout_directive
-- strategist:treasurer_directive
-- strategist:guide_directive
-- strategist:reviewer_directive
+  - strategist:weekly_directive
+  - strategist:midweek_adjustment
+  - strategist:architect_directive
+  - strategist:builder_directive
+  - strategist:deployer_directive
+  - strategist:designer_directive
+  - strategist:design_generate
+  - strategist:standup_synthesis
+  - strategist:sentinel_directive
+  - strategist:keeper_directive
+  - strategist:ember_directive
+  - strategist:forge_directive
+  - strategist:scout_directive
+  - strategist:treasurer_directive
+  - strategist:guide_directive
+  - strategist:reviewer_directive
 review_bypass: []

--- a/departments/finance/treasurer.yaml
+++ b/departments/finance/treasurer.yaml
@@ -67,6 +67,8 @@ data_sources:
   #     body: '{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["<WALLET_ADDRESS>","latest"]}'
 
   # ---- Infrastructure cost sources ----
+  # NOTE: litellm_spend requires LiteLLM proxy to be configured (not active in YCLAW).
+  # Treasurer will skip this source gracefully if the fetcher is not registered.
   - name: litellm_spend
     type: litellm_spend
     config: {}

--- a/packages/core/src/triggers/event-acl.ts
+++ b/packages/core/src/triggers/event-acl.ts
@@ -47,9 +47,19 @@ export const DEFAULT_ACL: AclMap = {
   'builder:spawn_failed': ['ao-callback'],
 
   // Strategist
+  'strategist:midweek_adjustment': ['strategist'],
   'strategist:architect_directive': ['strategist'],
   'strategist:ember_directive': ['strategist'],
   'strategist:designer_directive': ['strategist'],
+  'strategist:design_generate': ['strategist'],
+  'strategist:standup_synthesis': ['strategist'],
+  'strategist:sentinel_directive': ['strategist'],
+  'strategist:keeper_directive': ['strategist'],
+  'strategist:forge_directive': ['strategist'],
+  'strategist:scout_directive': ['strategist'],
+  'strategist:treasurer_directive': ['strategist'],
+  'strategist:guide_directive': ['strategist'],
+  'strategist:reviewer_directive': ['strategist'],
   'strategist:weekly_directive': ['strategist'],
 
   // Ember
@@ -61,16 +71,25 @@ export const DEFAULT_ACL: AclMap = {
   'reviewer:approved': ['reviewer'],
   'reviewer:flagged': ['reviewer'],
 
+  // Designer
+  'designer:design_review': ['designer'],
+  'designer:design_generated': ['designer'],
+
   // Forge
   'forge:asset_ready': ['forge'],
 
   // Keeper
   'keeper:support_case': ['keeper'],
 
+  // Treasurer
+  'treasurer:low_balance': ['treasurer'],
+  'treasurer:spend_report': ['treasurer'],
+
   // Deploy system
   'deploy:execute': ['deploy-system'],
   'deploy:review': ['deploy-system'],
   'deploy:approved': ['deploy-system'],
+  'deployer:deploy_complete': ['deployer'],
 
   // GitHub webhooks
   'github:pr_opened': ['github-webhook'],
@@ -101,6 +120,8 @@ export const DEFAULT_ACL: AclMap = {
   // Sentinel alerts
   'sentinel:alert': ['sentinel'],
   'sentinel:infra_alert': ['sentinel'],
+  'sentinel:status_report': ['sentinel'],
+  'sentinel:quality_report': ['sentinel'],
 
   // Discord (adapter publishes as 'discord', webhook as 'discord-webhook')
   'discord:message': ['discord', 'discord-webhook'],

--- a/packages/core/src/triggers/event-acl.ts
+++ b/packages/core/src/triggers/event-acl.ts
@@ -25,6 +25,7 @@ export const DEFAULT_ACL: AclMap = {
   'architect:deploy_review': ['architect'],
   'architect:deploy_complete': ['architect'],
   'architect:rebase_needed': ['architect'],
+  'architect:task_blocked': ['architect'],
 
   // Mechanic
   'mechanic:task_completed': ['mechanic'],
@@ -90,9 +91,22 @@ export const DEFAULT_ACL: AclMap = {
   ],
   'claudeception:reflect': ['system'],
 
+  // System events (budget enforcer publishes as 'system')
+  'system:agent:budget_exceeded': ['system'],
+  'system:agent:budget_warning': ['system'],
+
+  // Objective events
+  'objective:budget_exceeded': ['objective'],
+
+  // Sentinel alerts
+  'sentinel:alert': ['sentinel'],
+  'sentinel:infra_alert': ['sentinel'],
+
   // Discord (adapter publishes as 'discord', webhook as 'discord-webhook')
   'discord:message': ['discord', 'discord-webhook'],
   'discord:mention': ['discord', 'discord-webhook'],
+  'discord:thread_reply': ['discord', 'discord-webhook'],
+  'discord:react': ['discord', 'discord-webhook'],
 };
 
 // ─── ACL Check ───────────────────────────────────────────────────────────────

--- a/prompts/architect-workflow.md
+++ b/prompts/architect-workflow.md
@@ -1165,3 +1165,15 @@ If you discover a **security-critical issue** (credentials in code, auth bypass,
 4. If already merged, create a P0 revert issue immediately
 
 The `do-not-merge` label is still checked by all auto-merge rules and will block the merge.
+
+---
+
+## Task: daily_standup (triggered by cron: daily 13:02 UTC)
+
+Follow the Daily Standup Protocol (daily-standup-dev.md). Check PRs opened/reviewed/merged in last 24h, verify blockers, post to development channel. Keep it SHORT.
+
+---
+
+## Task: self_reflection (triggered by event: claudeception:reflect)
+
+Reflect on recent work. What went well? What failed? What would you do differently? Extract reusable learnings and patterns. Write findings to memory.

--- a/prompts/designer-workflow.md
+++ b/prompts/designer-workflow.md
@@ -320,6 +320,30 @@ If the issue has an open PR, post the Stitch project link as a PR comment for re
 
 ---
 
+## Task: daily_standup (triggered by cron: daily 13:08 UTC)
+
+Follow the Daily Standup Protocol (daily-standup-dev.md). Check design reviews done in last 24h, PRs with frontend changes, verify blockers, post to development channel.
+
+---
+
+## Task: integrate_design_update (triggered by event: forge:asset_ready)
+
+Receive a completed design asset from Forge. Review it against the design system, integrate into the appropriate component or page, and notify the development channel.
+
+---
+
+## Task: implement_design (triggered by event: architect:design_directive)
+
+Receive a design implementation directive from Architect. Create or update components per the spec. Follow design system guidelines.
+
+---
+
+## Task: self_reflection (triggered by event: claudeception:reflect)
+
+Reflect on recent work. What went well? What failed? What would you do differently? Extract reusable learnings and patterns. Write findings to memory.
+
+---
+
 ## Autonomy Doctrine (CRITICAL)
 
 You are an **autonomous decision-maker**. Your job is to DECIDE, not to recommend.

--- a/prompts/designer-workflow.md
+++ b/prompts/designer-workflow.md
@@ -7,7 +7,7 @@
 
 ---
 
-## Task: design_review (triggered by builder:pr_ready)
+## Task: design_review (triggered by ao:pr_ready)
 
 You received a PR to review for design system compliance. Follow this sequence exactly:
 
@@ -159,7 +159,7 @@ Post a Slack message:
 
 ---
 
-## Task: design_directive (triggered by designer:directive)
+## Task: design_directive (triggered by strategist:designer_directive)
 
 You received a directive from the Strategist. Execute it.
 
@@ -310,7 +310,7 @@ Post to [your-development-channel]:
 ```json
 {
   "channel": "[your-development-channel]",
-  "text": "🎨 Design generated for issue #<issue_number> via Google Stitch. <screen_count> screens created. Project: <project_title>. Ready for Builder implementation.",
+  "text": "🎨 Design generated for issue #<issue_number> via Google Stitch. <screen_count> screens created. Project: <project_title>. Ready for Architect/AO implementation.",
   "username": "Designer",
   "icon_emoji": ":art:"
 }

--- a/prompts/reviewer-workflow.md
+++ b/prompts/reviewer-workflow.md
@@ -116,6 +116,18 @@ Agents to watch: [any agents consistently scoring low]
 
 ---
 
+## Task: handle_directive (triggered by event: strategist:reviewer_directive)
+
+Receive and execute a review directive from the Strategist. This could be reviewing specific content, auditing a PR, or checking compliance on pending posts.
+
+---
+
+## Task: self_reflection (triggered by event: claudeception:reflect)
+
+Reflect on recent work. What went well? What failed? What would you do differently? Extract reusable learnings and patterns. Write findings to memory.
+
+---
+
 ## Rules
 
 - **Legal flags are absolute.** No override, no exceptions, no "it's probably fine."

--- a/prompts/sentinel-quality-workflow.md
+++ b/prompts/sentinel-quality-workflow.md
@@ -80,6 +80,42 @@ Publish a summary event:
 
 ---
 
+## Task: daily_standup (triggered by cron: daily 13:15 UTC)
+
+Follow the Daily Standup Protocol (daily-standup.md). Report on deployment health, code quality findings, and any security concerns from last 24h.
+
+---
+
+## Task: deployment_health (triggered by cron: every 4 hours)
+
+Check ECS service health for all YCLAW services (yclaw-production, yclaw-mc-production, yclaw-ao-production). Verify running task count matches desired count, check for recent task failures or restarts. Report issues to operations channel. If all healthy, exit silently.
+
+---
+
+## Task: weekly_repo_digest (triggered by cron: Friday 17:00 UTC)
+
+Generate a weekly repository activity digest. Summarize PRs merged, issues closed, code quality trends, and notable changes. Post to development channel.
+
+---
+
+## Task: post_deploy_verification (triggered by event: deployer:deploy_complete)
+
+After a deployment completes, verify service health, check for error spikes in logs, and confirm the deployment is stable. Report to operations channel.
+
+---
+
+## Task: handle_discord_infra (triggered by event: discord:mention)
+
+Handle infrastructure-related questions or requests from Discord mentions. Diagnose issues, check service health, and respond in the Discord thread.
+
+---
+
+## Task: self_reflection (triggered by event: claudeception:reflect)
+
+Reflect on recent work. What went well? What failed? What would you do differently? Extract reusable learnings and patterns. Write findings to memory.
+
+---
+
 ## Rules
 
 - **NEVER open refactoring PRs directly.** Report findings — let the Strategist decide what to fix.

--- a/prompts/strategist-workflow.md
+++ b/prompts/strategist-workflow.md
@@ -5,6 +5,35 @@
 
 ---
 
+## Task: heartbeat (triggered by cron: every 30 min)
+
+Follow the Strategist Heartbeat Protocol (strategist-heartbeat.md). Quick scan channels, check for stuck tasks, check PRs, unblock if needed, report only if noteworthy. Max 5 tool call rounds.
+
+---
+
+## Task: reconcile_pipeline (triggered by cron: every 10 min)
+
+Lightweight pipeline reconciliation. Check for:
+1. Open PRs with CI green + approved but not merged → merge them
+2. AO tasks that completed but weren't acknowledged → process callbacks
+3. Issues assigned to agents with no activity in 2+ hours → re-trigger
+
+Max 3 tool call rounds. If nothing to reconcile, exit silently.
+
+---
+
+## Task: model_review (triggered by cron: first Monday monthly)
+
+Review AI model performance and costs for the past month. Check execution cache stats, token usage patterns, and model effectiveness. Post summary to executive channel with recommendations.
+
+---
+
+## Task: self_reflection (triggered by event: claudeception:reflect)
+
+Reflect on recent work. What went well? What failed? What would you do differently? Extract reusable learnings and patterns. Write findings to memory.
+
+---
+
 ## Task: standup_synthesis (daily, 13:30 UTC)
 
 All agents submit standups between 13:00-13:25. You synthesize them.
@@ -237,6 +266,18 @@ Extract from event payload:
 **If AO infrastructure is down:**
 - Post to #yclaw-alerts with critical severity
 - Escalate to leadership
+
+---
+
+## Task: handle_blocked_task (triggered by event: architect:task_blocked)
+
+### Step 1: Read the blocker
+What is blocking the task? Missing access? Dependency on another task? Design decision needed?
+
+### Step 2: Unblock
+- Missing access/config: Check if you can resolve it directly, otherwise escalate to operations.
+- Dependency: Check if the dependency is in progress, re-prioritize if needed.
+- Decision needed: Make the decision if within your authority, otherwise escalate to executive channel.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes 5 issues preventing YCLAW agents from operating autonomously on ECS:

- **Event ACL gaps**: Budget enforcer events (`system:agent:budget_exceeded`, `system:agent:budget_warning`), Discord extended events (`thread_reply`, `react`), sentinel alerts, and objective events were missing from the fail-closed ACL — silently blocking legitimate event flow
- **Missing task definitions**: 15+ cron/event triggers referenced task names with no `## Task:` section in workflow markdown — agents ran with personality but zero procedure
- **Missing feedback loops**: Strategist had no event triggers for `sentinel:alert`, `ao:task_failed`, `ao:spawn_failed`, `architect:task_blocked` — system couldn't self-correct
- **Data source config**: Designer `github_repo` and Treasurer `litellm_spend` sources lacked fallback documentation for unregistered fetchers
- **Designer subscription gap**: `forge:asset_ready` trigger existed but wasn't in `event_subscriptions`

## Changes

| File | Change |
|------|--------|
| `event-acl.ts` | +8 ACL entries (system, objective, sentinel, discord, architect:task_blocked) |
| `strategist.yaml` | +4 event triggers, +4 event subscriptions |
| `strategist-workflow.md` | +5 task definitions (heartbeat, reconcile_pipeline, model_review, handle_blocked_task, self_reflection) |
| `architect-workflow.md` | +2 task definitions (daily_standup, self_reflection) |
| `designer-workflow.md` | +4 task definitions (daily_standup, integrate_design_update, implement_design, self_reflection) |
| `sentinel-quality-workflow.md` | +6 task definitions (daily_standup, deployment_health, weekly_repo_digest, post_deploy_verification, handle_discord_infra, self_reflection) |
| `reviewer-workflow.md` | +2 task definitions (handle_directive, self_reflection) |
| `designer.yaml` | +1 event subscription (forge:asset_ready), data source comment |
| `treasurer.yaml` | litellm_spend fallback note |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 1795 tests pass
- [ ] Deploy to ECS staging and verify agents execute tasks with instructions
- [ ] Verify budget events flow through ACL without silent drops
- [ ] Verify strategist receives and routes sentinel:alert events

🤖 Generated with [Claude Code](https://claude.com/claude-code)