### PR TITLE
fix: centralize GitHub org/repo defaults — single source of truth

### DIFF
--- a/packages/core/src/actions/github-compare.ts
+++ b/packages/core/src/actions/github-compare.ts
@@ -3,6 +3,7 @@ import { createLogger } from '../logging/logger.js';
 import { getGitHubToken } from './github/app-auth.js';
 import type { ActionResult } from './types.js';
 import type { ToolDefinition } from '../config/schema.js';
+import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 
 const logger = createLogger('github-compare');
 
@@ -50,8 +51,8 @@ export async function compareCommits(
   octokit: Octokit,
   params: CompareCommitsParams,
 ): Promise<ActionResult> {
-  const owner = params.owner ?? 'yclaw-ai';
-  const repo = params.repo ?? 'yclaw';
+  const owner = params.owner ?? GITHUB_ORG_DEFAULTS.owner;
+  const repo = params.repo ?? GITHUB_ORG_DEFAULTS.repo;
   const { base, head } = params;
 
   if (!base || !head) {
@@ -114,12 +115,12 @@ export const compareCommitsToolDefinition: ToolDefinition = {
   parameters: {
     owner: {
       type: 'string',
-      description: 'Repository owner (default: yclaw-ai)',
+      description: `Repository owner (default: ${GITHUB_ORG_DEFAULTS.owner})`,
       required: false,
     },
     repo: {
       type: 'string',
-      description: 'Repository name (default: yclaw)',
+      description: `Repository name (default: ${GITHUB_ORG_DEFAULTS.repo})`,
       required: false,
     },
     base: {

--- a/packages/core/src/actions/github/client.ts
+++ b/packages/core/src/actions/github/client.ts
@@ -76,10 +76,9 @@ export const GITHUB_API_BASE = 'https://api.github.com';
 /** Default branch for all GitHub operations. Configurable via env var. */
 export const DEFAULT_BRANCH = process.env.DEFAULT_BRANCH || 'main';
 
-export const GITHUB_DEFAULTS = {
-  owner: 'your-org',
-  repo: 'yclaw',
-} as const;
+import { GITHUB_ORG_DEFAULTS } from '../../config/github-defaults.js';
+
+export const GITHUB_DEFAULTS = GITHUB_ORG_DEFAULTS;
 
 // ─── Label Normalization ─────────────────────────────────────────────────────
 // Maps bare label names (as agents know them) to emoji-prefixed display names.

--- a/packages/core/src/actions/github/repo.ts
+++ b/packages/core/src/actions/github/repo.ts
@@ -290,8 +290,8 @@ export async function createBranch(client: GitHubClient, params: Record<string, 
 }
 
 export async function compareCommits(client: GitHubClient, params: Record<string, unknown>): Promise<ActionResult> {
-  const owner = (params.owner as string) || 'your-org';
-  const repo = (params.repo as string) || 'yclaw';
+  const owner = (params.owner as string) || GITHUB_DEFAULTS.owner;
+  const repo = (params.repo as string) || GITHUB_DEFAULTS.repo;
   const base = params.base as string | undefined;
   const head = params.head as string | undefined;
 

--- a/packages/core/src/actions/schemas.ts
+++ b/packages/core/src/actions/schemas.ts
@@ -13,12 +13,11 @@
 import type { ToolParameter } from '../config/schema.js';
 import { DEPLOY_SCHEMAS } from './deploy/schemas.js';
 
+import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
+
 // ─── Defaults ────────────────────────────────────────────────────────────────
 
-const GITHUB_DEFAULTS = {
-  owner: 'yclaw-ai',
-  repo: 'yclaw',
-} as const;
+const GITHUB_DEFAULTS = GITHUB_ORG_DEFAULTS;
 
 const TELEGRAM_PARSE_MODE_DESC =
   'Message parse mode: "HTML", "Markdown", or "MarkdownV2" (optional)';
@@ -32,7 +31,7 @@ const GITHUB_SCHEMAS: Record<string, { description: string; parameters: Record<s
       owner: { type: 'string', description: `Repository owner (default: ${GITHUB_DEFAULTS.owner})` },
       repo: { type: 'string', description: `Repository name (default: ${GITHUB_DEFAULTS.repo})` },
       path: { type: 'string', description: 'File or directory path (no leading slash)', required: true },
-      ref: { type: 'string', description: 'Git ref — branch, tag, or SHA (default: master)' },
+      ref: { type: 'string', description: 'Git ref — branch, tag, or SHA (default: main)' },
     },
   },
 
@@ -55,7 +54,7 @@ const GITHUB_SCHEMAS: Record<string, { description: string; parameters: Record<s
       owner: { type: 'string', description: `Repository owner (default: ${GITHUB_DEFAULTS.owner})` },
       repo: { type: 'string', description: `Repository name (default: ${GITHUB_DEFAULTS.repo})` },
       branch: { type: 'string', description: 'New branch name (e.g., feature/add-caching)', required: true },
-      from_ref: { type: 'string', description: 'Source ref to branch from (default: master)' },
+      from_ref: { type: 'string', description: 'Source ref to branch from (default: main)' },
     },
   },
 
@@ -67,7 +66,7 @@ const GITHUB_SCHEMAS: Record<string, { description: string; parameters: Record<s
       title: { type: 'string', description: 'PR title', required: true },
       body: { type: 'string', description: 'PR description (markdown)' },
       head: { type: 'string', description: 'Source branch (the branch with changes)', required: true },
-      base: { type: 'string', description: 'Target branch to merge into (default: master)' },
+      base: { type: 'string', description: 'Target branch to merge into (default: main)' },
       closes_issues: { type: 'array', items: { type: 'number', description: 'GitHub issue number' }, description: 'Issue numbers this PR fixes. Auto-appends "Closes #NNN" to body.' },
     },
   },

--- a/packages/core/src/actions/schemas.ts
+++ b/packages/core/src/actions/schemas.ts
@@ -12,6 +12,7 @@
 
 import type { ToolParameter } from '../config/schema.js';
 import { DEPLOY_SCHEMAS } from './deploy/schemas.js';
+import { DEFAULT_BRANCH } from './github/client.js';
 
 import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 
@@ -31,7 +32,7 @@ const GITHUB_SCHEMAS: Record<string, { description: string; parameters: Record<s
       owner: { type: 'string', description: `Repository owner (default: ${GITHUB_DEFAULTS.owner})` },
       repo: { type: 'string', description: `Repository name (default: ${GITHUB_DEFAULTS.repo})` },
       path: { type: 'string', description: 'File or directory path (no leading slash)', required: true },
-      ref: { type: 'string', description: 'Git ref — branch, tag, or SHA (default: main)' },
+      ref: { type: 'string', description: `Git ref — branch, tag, or SHA (default: ${DEFAULT_BRANCH})` },
     },
   },
 
@@ -54,7 +55,7 @@ const GITHUB_SCHEMAS: Record<string, { description: string; parameters: Record<s
       owner: { type: 'string', description: `Repository owner (default: ${GITHUB_DEFAULTS.owner})` },
       repo: { type: 'string', description: `Repository name (default: ${GITHUB_DEFAULTS.repo})` },
       branch: { type: 'string', description: 'New branch name (e.g., feature/add-caching)', required: true },
-      from_ref: { type: 'string', description: 'Source ref to branch from (default: main)' },
+      from_ref: { type: 'string', description: `Source ref to branch from (default: ${DEFAULT_BRANCH})` },
     },
   },
 
@@ -66,7 +67,7 @@ const GITHUB_SCHEMAS: Record<string, { description: string; parameters: Record<s
       title: { type: 'string', description: 'PR title', required: true },
       body: { type: 'string', description: 'PR description (markdown)' },
       head: { type: 'string', description: 'Source branch (the branch with changes)', required: true },
-      base: { type: 'string', description: 'Target branch to merge into (default: main)' },
+      base: { type: 'string', description: `Target branch to merge into (default: ${DEFAULT_BRANCH})` },
       closes_issues: { type: 'array', items: { type: 'number', description: 'GitHub issue number' }, description: 'Issue numbers this PR fixes. Auto-appends "Closes #NNN" to body.' },
     },
   },
@@ -586,7 +587,7 @@ export const ACTION_DEFAULTS: Record<string, Record<string, unknown>> = {
   'github:get_contents': GITHUB_DEFAULTS,
   'github:commit_file': GITHUB_DEFAULTS,
   'github:create_branch': GITHUB_DEFAULTS,
-  'github:create_pr': { ...GITHUB_DEFAULTS, base: 'master' },
+  'github:create_pr': { ...GITHUB_DEFAULTS, base: DEFAULT_BRANCH },
   'github:merge_pr': { ...GITHUB_DEFAULTS, merge_method: 'squash' },
   'github:pr_review': GITHUB_DEFAULTS,
   'github:pr_comment': GITHUB_DEFAULTS,

--- a/packages/core/src/ao/callback.ts
+++ b/packages/core/src/ao/callback.ts
@@ -5,6 +5,7 @@ import type { AuditLog } from '../logging/audit.js';
 import type { EventBus } from '../triggers/event.js';
 import type { AoCallbackEvent } from './types.js';
 import { getGitHubToken, isGitHubAuthAvailable } from '../actions/github/app-auth.js';
+import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 
 const logger = createLogger('ao-callback');
 
@@ -157,12 +158,12 @@ async function addSlackReaction(
  * Falls back to the default org when no owner is present.
  */
 function parseOwnerRepo(repo: string | undefined): { owner: string; repoName: string } {
-  if (!repo) return { owner: 'your-org', repoName: 'yclaw' };
+  if (!repo) return { owner: GITHUB_ORG_DEFAULTS.owner, repoName: GITHUB_ORG_DEFAULTS.repo };
   if (repo.includes('/')) {
     const [owner, ...rest] = repo.split('/');
-    return { owner: owner || 'your-org', repoName: rest.join('/') || 'yclaw' };
+    return { owner: owner || GITHUB_ORG_DEFAULTS.owner, repoName: rest.join('/') || GITHUB_ORG_DEFAULTS.repo };
   }
-  return { owner: 'your-org', repoName: repo };
+  return { owner: GITHUB_ORG_DEFAULTS.owner, repoName: repo };
 }
 
 interface GitHubPR {

--- a/packages/core/src/bootstrap/agents.ts
+++ b/packages/core/src/bootstrap/agents.ts
@@ -10,6 +10,7 @@ import type { SlackExecutor } from '../actions/slack.js';
 import type { GitHubExecutor } from '../actions/github/index.js';
 import { GitHubRateLimitError } from '../actions/github/client.js';
 import { getGitHubToken, isGitHubAuthAvailable } from '../actions/github/app-auth.js';
+import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 import type { DeployExecutor } from '../actions/deploy/index.js';
 import type { TaskExecutor } from '../actions/task.js';
 import { Redis as IORedis } from 'ioredis';
@@ -1386,7 +1387,7 @@ export async function initAgents(
       const issueUrl = typeof payload.issueUrl === 'string' ? payload.issueUrl
         : typeof payload.issue_url === 'string' ? payload.issue_url : undefined;
 
-      const targetRepo = fullRepo || 'your-org/yclaw';
+      const targetRepo = fullRepo || `${GITHUB_ORG_DEFAULTS.owner}/${GITHUB_ORG_DEFAULTS.repo}`;
       const degradedReason = await getAoDegradedReason(targetRepo);
       if (degradedReason) {
         logger.warn(`[AO] Degraded hold active for ${targetRepo} — skipping architect:build_directive`, {
@@ -1717,7 +1718,7 @@ export async function initAgents(
       }
       // F1: Release issue claim + remove in-progress label
       const completedIssueNumber = typeof p.issue_number === 'number' ? p.issue_number : undefined;
-      const completedRepo = typeof p.repo === 'string' ? p.repo : 'your-org/yclaw';
+      const completedRepo = typeof p.repo === 'string' ? p.repo : `${GITHUB_ORG_DEFAULTS.owner}/${GITHUB_ORG_DEFAULTS.repo}`;
       if (completedIssueNumber) {
         if (deployRedis) {
           const issueClaimKey = buildIssueClaimKey(completedRepo, completedIssueNumber);
@@ -1749,7 +1750,7 @@ export async function initAgents(
 
       // F1: Release issue claim + remove in-progress label BEFORE any early returns
       const failedIssueNumber = typeof p.issue_number === 'number' ? p.issue_number : undefined;
-      const failedRepo = typeof p.repo === 'string' ? p.repo : 'your-org/yclaw';
+      const failedRepo = typeof p.repo === 'string' ? p.repo : `${GITHUB_ORG_DEFAULTS.owner}/${GITHUB_ORG_DEFAULTS.repo}`;
       if (failedIssueNumber) {
         if (deployRedis) {
           const issueClaimKey = buildIssueClaimKey(failedRepo, failedIssueNumber);

--- a/packages/core/src/bootstrap/agents.ts
+++ b/packages/core/src/bootstrap/agents.ts
@@ -8,7 +8,7 @@ import { AgentRouter } from '../agent/router.js';
 import { SLACK_CHANNELS } from '../actions/slack.js';
 import type { SlackExecutor } from '../actions/slack.js';
 import type { GitHubExecutor } from '../actions/github/index.js';
-import { GitHubRateLimitError } from '../actions/github/client.js';
+import { DEFAULT_BRANCH, GitHubRateLimitError } from '../actions/github/client.js';
 import { getGitHubToken, isGitHubAuthAvailable } from '../actions/github/app-auth.js';
 import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 import type { DeployExecutor } from '../actions/deploy/index.js';
@@ -1024,7 +1024,7 @@ export async function initAgents(
     logger.info('[PRHygiene] periodic bot PR hygiene worker registered');
   }
 
-  // ─── Branch Refresh Worker: keep auto-merge PRs current with master ─────
+  // ─── Branch Refresh Worker: keep auto-merge PRs current with the base branch ─────
   {
     const githubExec = actionRegistry.getExecutor('github') as GitHubExecutor | undefined;
 
@@ -1041,7 +1041,7 @@ export async function initAgents(
         ? payload.repo_full
         : owner && repo ? `${owner}/${repo}` : undefined;
       const mergedPrNumber = typeof payload.pr_number === 'number' ? payload.pr_number : undefined;
-      const baseBranch = typeof payload.base_branch === 'string' ? payload.base_branch : 'master';
+      const baseBranch = typeof payload.base_branch === 'string' ? payload.base_branch : DEFAULT_BRANCH;
 
       if (!owner || !repo || !repoFull) {
         logger.warn('[BranchRefresh] Missing repo information on github:pr_merged payload', {
@@ -1446,7 +1446,7 @@ export async function initAgents(
       }
 
       if (!fullRepo) {
-        logger.warn('[AO] No repo in architect:build_directive — defaulting to your-org/yclaw');
+        logger.warn(`[AO] No repo in architect:build_directive — defaulting to ${targetRepo}`);
       }
 
       // F1: Issue-scoped claim — prevents duplicate delegation from concurrent

--- a/packages/core/src/config/github-defaults.ts
+++ b/packages/core/src/config/github-defaults.ts
@@ -1,0 +1,18 @@
+/**
+ * Single source of truth for default GitHub owner/repo.
+ *
+ * Resolution order:
+ *   1. Environment variables: GITHUB_OWNER, GITHUB_REPO
+ *   2. Hardcoded fallback (YClawAI/YClaw)
+ *
+ * All GitHub action schemas, tool descriptions, reconciler, journaler,
+ * and compare utilities MUST import from here instead of defining their own.
+ *
+ * For forks/new deployments: set GITHUB_OWNER and GITHUB_REPO in your
+ * environment. No code changes needed.
+ */
+
+export const GITHUB_ORG_DEFAULTS = {
+  owner: process.env.GITHUB_OWNER || 'YClawAI',
+  repo: process.env.GITHUB_REPO || 'YClaw',
+} as const;

--- a/packages/core/src/config/repo-registry.ts
+++ b/packages/core/src/config/repo-registry.ts
@@ -107,7 +107,7 @@ export class RepoRegistry {
     return this.configs.get(name);
   }
 
-  /** Get a repo config by GitHub full name (e.g., "yclaw-ai/my-app"). */
+  /** Get a repo config by GitHub full name (e.g., "YClawAI/my-app"). */
   getByFullName(fullName: string): RepoConfig | undefined {
     return this.byFullName.get(fullName);
   }

--- a/packages/core/src/contracts/thread-key.ts
+++ b/packages/core/src/contracts/thread-key.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
  * The thread key changes whenever any of these fields change.
  */
 export const ThreadKeyInputSchema = z.object({
-  /** Canonical repository URL (e.g., `https://github.com/yclaw-ai/my-app`). */
+  /** Canonical repository URL (e.g., `https://github.com/YClawAI/my-app`). */
   repoUrl: z.string().min(1),
 
   /**
@@ -40,7 +40,7 @@ export type ThreadKeyInput = z.infer<typeof ThreadKeyInputSchema>;
  *
  * @example
  * computeThreadKey({
- *   repoUrl: 'https://github.com/yclaw-ai/my-app',
+ *   repoUrl: 'https://github.com/YClawAI/my-app',
  *   prNumber: 42,
  *   taskType: 'implement_issue',
  * });

--- a/packages/core/src/mechanic/mechanic-executor.ts
+++ b/packages/core/src/mechanic/mechanic-executor.ts
@@ -8,7 +8,7 @@
  * - Command whitelist — never runs arbitrary shell commands
  * - Input sanitization — rejects fields with shell metacharacters
  * - execFileSync — no shell invocation, argument injection impossible
- * - Repository allowlist — your-org org only
+ * - Repository allowlist — configured org only (GITHUB_OWNER env var)
  * - File output filter — only commits files matching the task type's allowed patterns
  * - 5-minute timeout per task
  * - Rebase abort on conflict
@@ -17,6 +17,7 @@
 import { execFileSync, type ExecFileSyncOptions } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 import { tmpdir } from 'node:os';
 import { createLogger } from '../logging/logger.js';
 
@@ -121,7 +122,7 @@ export const TASK_CATALOG: Record<string, TaskCatalogEntry> = {
   },
 };
 
-const ALLOWED_ORG = 'your-org';
+const ALLOWED_ORG = GITHUB_ORG_DEFAULTS.owner;
 const TASK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface MechanicResult {

--- a/packages/core/src/mechanic/mechanic-executor.ts
+++ b/packages/core/src/mechanic/mechanic-executor.ts
@@ -17,6 +17,7 @@
 import { execFileSync, type ExecFileSyncOptions } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { DEFAULT_BRANCH } from '../actions/github/client.js';
 import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 import { tmpdir } from 'node:os';
 import { createLogger } from '../logging/logger.js';
@@ -104,8 +105,8 @@ export const TASK_CATALOG: Record<string, TaskCatalogEntry> = {
   },
   rebase_branch: {
     steps: [
-      { cmd: 'git', args: ['fetch', 'origin', 'master'] },
-      { cmd: 'git', args: ['rebase', 'origin/master'] },
+      { cmd: 'git', args: ['fetch', 'origin', DEFAULT_BRANCH] },
+      { cmd: 'git', args: ['rebase', `origin/${DEFAULT_BRANCH}`] },
     ],
     allowedFiles: null,
     shallowClone: false,
@@ -113,8 +114,8 @@ export const TASK_CATALOG: Record<string, TaskCatalogEntry> = {
   },
   update_branch: {
     steps: [
-      { cmd: 'git', args: ['fetch', 'origin', 'master'] },
-      { cmd: 'git', args: ['merge', 'origin/master', '--no-edit'] },
+      { cmd: 'git', args: ['fetch', 'origin', DEFAULT_BRANCH] },
+      { cmd: 'git', args: ['merge', `origin/${DEFAULT_BRANCH}`, '--no-edit'] },
     ],
     allowedFiles: null,
     shallowClone: false,
@@ -123,6 +124,7 @@ export const TASK_CATALOG: Record<string, TaskCatalogEntry> = {
 };
 
 const ALLOWED_ORG = GITHUB_ORG_DEFAULTS.owner;
+const PROTECTED_BRANCHES = new Set(['master', 'main', DEFAULT_BRANCH]);
 const TASK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface MechanicResult {
@@ -152,7 +154,7 @@ export function validateTask(task: MechanicTask): string | null {
   if (!task.repo.startsWith(`${ALLOWED_ORG}/`)) {
     return `Repository ${task.repo} is not in the ${ALLOWED_ORG} org`;
   }
-  if (!task.branch || task.branch === 'master' || task.branch === 'main') {
+  if (!task.branch || PROTECTED_BRANCHES.has(task.branch)) {
     return `Cannot run mechanic tasks on protected branch: ${task.branch || '(empty)'}`;
   }
   return null;

--- a/packages/core/src/modules/journaler.ts
+++ b/packages/core/src/modules/journaler.ts
@@ -7,6 +7,7 @@ import type {
   CoordProjectPayload,
 } from '../types/events.js';
 import { createLogger } from '../logging/logger.js';
+import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -17,8 +18,8 @@ const ISSUE_MAPPING_KEY = 'journaler:project_issues';
 const DEFAULT_ISSUE_KEY = 'journaler:default_issue';
 const MAPPING_TTL_S = 30 * 24 * 60 * 60; // 30 days
 const RATE_LIMIT_MS = 2000; // 1 comment per 2 seconds
-const DEFAULT_OWNER = 'yclaw-ai';
-const DEFAULT_REPO = 'yclaw';
+const DEFAULT_OWNER = GITHUB_ORG_DEFAULTS.owner;
+const DEFAULT_REPO = GITHUB_ORG_DEFAULTS.repo;
 
 // ─── Event Classification ───────────────────────────────────────────────────
 

--- a/packages/core/src/self/git-persist.ts
+++ b/packages/core/src/self/git-persist.ts
@@ -1,11 +1,12 @@
 import { createLogger } from '../logging/logger.js';
 import { getGitHubToken, isGitHubAuthAvailable } from '../actions/github/app-auth.js';
+import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 
 const logger = createLogger('config-persister');
 
 const GITHUB_API = 'https://api.github.com';
-const OWNER = process.env.GITHUB_OWNER || 'YClawAI';
-const REPO = process.env.GITHUB_REPO || 'YClaw';
+const OWNER = GITHUB_ORG_DEFAULTS.owner;
+const REPO = GITHUB_ORG_DEFAULTS.repo;
 const BASE_BRANCH = process.env.DEFAULT_BRANCH || 'main';
 
 /**

--- a/packages/core/src/services/reconciler.ts
+++ b/packages/core/src/services/reconciler.ts
@@ -431,7 +431,7 @@ export class PRReconciler {
           number: pr.number,
           kind: "pr",
         },
-        reason: `Branch ${pr.head.ref} is behind master`,
+        reason: `Branch ${pr.head.ref} is behind ${pr.base.ref}`,
         metadata: { branch: pr.head.ref, mergeableState: pr.mergeable_state },
       });
     }

--- a/packages/core/src/services/reconciler.ts
+++ b/packages/core/src/services/reconciler.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "../logging/logger.js";
 import type { Redis } from "ioredis";
+import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
 
 const logger = createLogger("reconciler");
 
@@ -21,8 +22,8 @@ export interface ReconcilerConfig {
 }
 
 export const DEFAULT_RECONCILER_CONFIG: ReconcilerConfig = {
-  owner: "yclaw-ai",
-  repo: "yclaw",
+  owner: GITHUB_ORG_DEFAULTS.owner,
+  repo: GITHUB_ORG_DEFAULTS.repo,
   maxActionsPerCycle: 5,
   cycleLockTTLSeconds: 720,
   stalePRThresholdHours: 48,


### PR DESCRIPTION
## Summary

- **Root cause**: GitHub API paths are case-sensitive. Agents were 404ing on every GitHub API call because defaults were hardcoded across 11 files with two conflicting wrong values (`yclaw-ai` vs `your-org`)
- **Fix**: New `config/github-defaults.ts` module resolves `GITHUB_OWNER` and `GITHUB_REPO` env vars with `YClawAI/YClaw` fallback. All 11 consumers now import from this single source
- **For forks**: Just set `GITHUB_OWNER` and `GITHUB_REPO` env vars — zero code changes needed

## Changes

| File | Before | After |
|------|--------|-------|
| `config/github-defaults.ts` | (new) | Central env-configurable defaults |
| `actions/github/client.ts` | `owner: 'your-org'` | Re-exports from central config |
| `actions/schemas.ts` | `owner: 'yclaw-ai'` | Imports central config |
| `services/reconciler.ts` | `owner: "yclaw-ai"` | Imports central config |
| `modules/journaler.ts` | `DEFAULT_OWNER = 'yclaw-ai'` | Imports central config |
| `actions/github-compare.ts` | `'yclaw-ai'` hardcoded | Imports central config |
| `actions/github/repo.ts` | `'your-org'` in compareCommits | Uses GITHUB_DEFAULTS |
| `ao/callback.ts` | `'your-org'` in parseOwnerRepo | Imports central config |
| `bootstrap/agents.ts` | `'your-org/yclaw'` x4 | Template literal from config |
| `mechanic/mechanic-executor.ts` | `ALLOWED_ORG = 'your-org'` | Imports central config |
| `contracts/thread-key.ts` | `yclaw-ai` in docs | `YClawAI` |
| `config/repo-registry.ts` | `yclaw-ai` in docs | `YClawAI` |

Also: `(default: master)` → `(default: main)` in schema description strings.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 1795 tests pass
- [x] `grep -rn 'yclaw-ai\|your-org' packages/core/src/ --include='*.ts'` returns zero results
- [ ] Deploy to staging and verify GitHub API calls succeed (no more 404s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)