### PR TITLE
fix: inject agentName into discord/slack actions from executor

### DIFF
--- a/packages/core/src/agent/executor.ts
+++ b/packages/core/src/agent/executor.ts
@@ -1064,6 +1064,12 @@ export class AgentExecutor {
       return actionResultCache.get(cacheKey);
     }
 
+    // Inject agent identity for Discord/Slack actions so messages post
+    // under the correct agent name rather than defaulting to 'system'.
+    if (actionName.startsWith('discord:') || actionName.startsWith('slack:')) {
+      if (!args.agentName) args.agentName = config.name;
+    }
+
     const result = await this.actionRegistry.execute(actionName, args);
 
     // Cache successful read-only results for dedup


### PR DESCRIPTION
## Problem

PR #56 added webhook identity to `discord:message` but agent text posts still show as **🔔 System** instead of **🔐 Sentinel** (etc).

The issue: agents call `discord:message` with just `{channel, text}` — they never include `agentName`. The `DiscordExecutor.postMessage()` defaults to `'system'`, and `getAgentIdentity('system')` returns the fallback identity (🔔 + capitalized name).

## Evidence

Sentinel standup posted at 14:58:32 UTC today:
- Correct channel (yclaw-operations) ✅
- Via webhook (not Tyrion bot) ✅  
- Username: **🔔 System** ❌ — should be **🔐 Sentinel**

## Fix

One-liner in `packages/core/src/agent/executor.ts`: inject `config.name` as `agentName` into action args before dispatching discord/slack actions. The executor already has `config.name` — the agent just can't pass it because it doesn't know its own name at the tool-call level.

```typescript
if (actionName.startsWith('discord:') || actionName.startsWith('slack:')) {
  if (!args.agentName) args.agentName = config.name;
}
```

## Testing

Trigger `daily_standup` for any agent → Discord post should show agent emoji + name, not 🔔 System.