### PR TITLE
fix: AO pipeline — claim release, defensive repo validation, Cloud Map for CORE

### DIFF
--- a/ao/ao-bridge-server.mjs
+++ b/ao/ao-bridge-server.mjs
@@ -410,7 +410,19 @@ async function ensureRepoMirror(repo) {
   return withRepoLock(repoName, async () => {
     await ensureFreeDiskSpace();
 
-    if (!existsSync(join(repoPath, '.git'))) {
+    if (existsSync(repoPath)) {
+      // Validate it's actually a working git repo
+      try {
+        await runCommand('git', ['-C', repoPath, 'rev-parse', '--is-inside-work-tree'], null, 10000);
+        console.log(`[ao-bridge] Valid repo mirror found at ${repoPath}`);
+      } catch {
+        // Directory exists but isn't a valid git repo — corrupt/partial clone
+        console.warn(`[ao-bridge] Invalid repo at ${repoPath}, removing and recloning...`);
+        rmSync(repoPath, { recursive: true, force: true });
+        console.log(`[ao-bridge] Bootstrapping fresh repo mirror for ${repo}`);
+        await runCommand('git', ['clone', '--depth', '50', repoUrl, repoPath], REPO_ROOT, 180000);
+      }
+    } else {
       console.log(`[ao-bridge] Bootstrapping missing repo mirror for ${repo}`);
       await runCommand('git', ['clone', '--depth', '50', repoUrl, repoPath], REPO_ROOT, 180000);
     }

--- a/ao/entrypoint.sh
+++ b/ao/entrypoint.sh
@@ -138,9 +138,18 @@ if [ -n "$YCLAW_REPOS" ]; then
     repo_name=$(echo "$repo" | cut -d'/' -f2)
     repo_slug_name=$(repo_slug "$repo")
     repo_url="https://github.com/${repo}.git"
+    if [ -d "/data/worktrees/${repo_slug_name}" ]; then
+      if ! git -C "/data/worktrees/${repo_slug_name}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "[ao-entrypoint] WARNING: /data/worktrees/${repo_slug_name} exists but is not a valid git repo — removing corrupt clone"
+        rm -rf "/data/worktrees/${repo_slug_name}"
+      fi
+    fi
     if [ ! -d "/data/worktrees/${repo_slug_name}/.git" ]; then
       echo "[ao-entrypoint] Cloning ${repo} (shallow)..."
-      git clone --depth 50 "$repo_url" "/data/worktrees/${repo_slug_name}"
+      if ! git clone --depth 50 "$repo_url" "/data/worktrees/${repo_slug_name}"; then
+        echo "[ao-entrypoint] FATAL: git clone failed for ${repo}" >&2
+        exit 1
+      fi
     else
       echo "[ao-entrypoint] ${repo_name} already cloned, syncing to remote default branch..."
       cd "/data/worktrees/${repo_slug_name}"

--- a/packages/core/src/bootstrap/agents.ts
+++ b/packages/core/src/bootstrap/agents.ts
@@ -31,6 +31,7 @@ import type { SettingsOverlay } from '../config/settings-overlay.js';
 import type { ServiceContext } from './services.js';
 import type { ActionContext } from './actions.js';
 import { AoBridge } from '../ao/bridge.js';
+import type { AoSpawnResponse } from '../ao/types.js';
 import type { AgentEvent } from '../config/schema.js';
 import type { YClawEvent } from '../types/events.js';
 import {
@@ -1478,15 +1479,50 @@ export async function initAgents(
         : typeof payload.description === 'string' ? payload.description
         : 'Event: architect:build_directive';
 
-      const result = await aoBridge.spawn({
-        issueUrl,
-        issueNumber,
-        repo: targetRepo,
-        directive,
-        orchestrator: aoOrchestrator,
-        context: JSON.stringify({ eventKey: 'architect:build_directive', correlationId: event.correlationId, ...payload }),
-        priority: typeof payload.priority === 'string' ? payload.priority as 'P0' | 'P1' | 'P2' | 'P3' : undefined,
-      });
+      // Helper: release issue claim immediately (spawn failed, ao:task_completed/failed won't fire)
+      const releaseIssueClaim = async () => {
+        if (issueNumber && deployRedis) {
+          const issueClaimKey = buildIssueClaimKey(targetRepo, issueNumber);
+          await deployRedis.del(issueClaimKey).catch((err: unknown) => {
+            logger.warn('[AO] Failed to release issue claim after spawn failure', {
+              issueNumber, error: err instanceof Error ? err.message : String(err),
+            });
+          });
+          logger.info('[AO] Released issue claim after spawn failure', { repo: targetRepo, issueNumber });
+        }
+      };
+
+      let result: AoSpawnResponse | null | undefined;
+      try {
+        result = await aoBridge.spawn({
+          issueUrl,
+          issueNumber,
+          repo: targetRepo,
+          directive,
+          orchestrator: aoOrchestrator,
+          context: JSON.stringify({ eventKey: 'architect:build_directive', correlationId: event.correlationId, ...payload }),
+          priority: typeof payload.priority === 'string' ? payload.priority as 'P0' | 'P1' | 'P2' | 'P3' : undefined,
+        });
+      } catch (spawnErr: unknown) {
+        // Spawn threw — release claim so the issue can be retried
+        await releaseIssueClaim();
+        logger.error('[AO] aoBridge.spawn() threw for architect:build_directive', {
+          repo: targetRepo, issueNumber, error: spawnErr instanceof Error ? spawnErr.message : String(spawnErr),
+        });
+        await markAoDegraded(targetRepo, 'ao_unreachable');
+        await emitAoSpawnFailure({
+          eventKey: 'architect:build_directive',
+          issueUrl,
+          issueNumber,
+          repo: targetRepo,
+          reason: 'ao_unreachable',
+          error: spawnErr instanceof Error ? spawnErr.message : String(spawnErr),
+          correlationId: event.correlationId,
+          summaryText: `AO degraded for ${targetRepo} — spawn threw: ${spawnErr instanceof Error ? spawnErr.message : String(spawnErr)}`,
+          degraded: true,
+        });
+        return;
+      }
 
       if (result?.status === 'spawned') {
         logger.info(`[AO] Routed architect:build_directive to AO: ${result.id}`, { repo: targetRepo, issueNumber });
@@ -1509,6 +1545,8 @@ export async function initAgents(
           }
         }
       } else {
+        // Spawn returned non-spawned status — release claim so the issue can be retried
+        await releaseIssueClaim();
         logger.error('[AO] Failed to spawn AO task for architect:build_directive', {
           status: result?.status, error: result?.error, repo: targetRepo, issueNumber,
         });

--- a/prompts/strategist-workflow.md
+++ b/prompts/strategist-workflow.md
@@ -16,7 +16,9 @@ Follow the Strategist Heartbeat Protocol (strategist-heartbeat.md). Quick scan c
 Lightweight pipeline reconciliation. Check for:
 1. Open PRs with CI green + approved but not merged → merge them
 2. AO tasks that completed but weren't acknowledged → process callbacks
-3. Issues assigned to agents with no activity in 2+ hours → re-trigger
+3. Issues assigned to agents with no activity in 2+ hours → re-trigger via delegation
+
+**Delegation rule:** When you identify open issues that require code changes and are not currently in-progress (no `in-progress` label, no recent AO spawn), publish a `build_directive` event targeting the Architect using `event:publish` with `{source: 'strategist', type: 'architect_directive', payload: {issue: <number>, repo: '<owner/repo>', task: '<description>'}}`. Do not attempt to fix code yourself — delegate to Architect, who will analyze and delegate to AO/Builder.
 
 Max 3 tool call rounds. If nothing to reconcile, exit silently.
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -784,6 +784,11 @@ resource "aws_ecs_service" "agents" {
     container_port   = 3000
   }
 
+  # Cloud Map service discovery — registers yclaw-agents.yclaw.internal automatically
+  service_registries {
+    registry_arn = aws_service_discovery_service.agents.arn
+  }
+
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 100
 
@@ -798,13 +803,34 @@ resource "aws_ecs_service" "agents" {
 }
 
 # ─── Service Discovery (Cloud Map) ───────────────────────────────────────────
-# Creates ao.yclaw.internal DNS that auto-resolves to the AO task's private IP.
-# When AO restarts, AWS updates the A-record automatically within seconds.
+# Creates internal DNS records that auto-resolve to ECS task private IPs:
+#   - yclaw-agents.yclaw.internal → CORE (port 3000)
+#   - ao.yclaw.internal           → AO   (port 8420)
+# When a service restarts, AWS updates the A-record automatically within seconds.
 
 resource "aws_service_discovery_private_dns_namespace" "internal" {
   name        = "yclaw.internal"
   description = "YCLAW internal service discovery"
   vpc         = var.vpc_id
+}
+
+resource "aws_service_discovery_service" "agents" {
+  name = "yclaw-agents"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.internal.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
 }
 
 resource "aws_service_discovery_service" "ao" {
@@ -865,7 +891,7 @@ resource "aws_ecs_task_definition" "ao" {
         { name = "NODE_ENV", value = var.environment },
         { name = "YCLAW_REPOS", value = "YClawAI/YClaw" },
         { name = "YCLAW_AO_OVERLAY_REPO", value = "YClawAI/YClaw" },
-        { name = "AO_CALLBACK_URL", value = "https://${aws_lb.gaze.dns_name}/api/ao/callback" },
+        { name = "AO_CALLBACK_URL", value = "http://yclaw-agents.yclaw.internal:3000/api/ao/callback" },
       ]
 
       secrets = [
@@ -972,6 +998,11 @@ output "ao_ecr_repository_url" {
 
 output "ao_service_name" {
   value = aws_ecs_service.ao.name
+}
+
+output "agents_internal_dns" {
+  value       = "yclaw-agents.${aws_service_discovery_private_dns_namespace.internal.name}"
+  description = "Internal DNS name for CORE service (resolves within VPC only)"
 }
 
 output "ao_internal_dns" {


### PR DESCRIPTION
## Summary

- **Redis claim release on spawn failure**: When `aoBridge.spawn()` fails or throws, the issue claim is now released immediately instead of staying locked for 2 hours (ISSUE_CLAIM_TTL_SEC=7200). Prevents failed spawns from blocking all retry attempts.
- **Defensive repo validation**: Both `ensureRepoMirror()` (bridge) and `entrypoint.sh` now validate repos with `git rev-parse --is-inside-work-tree` before syncing. Corrupt/partial clones (directory exists but invalid `.git`) are removed and recloned. Clone failures in entrypoint now abort startup with `exit 1`.
- **Cloud Map for CORE**: Added `yclaw-agents.yclaw.internal` Cloud Map service + `service_registries` on the CORE ECS service, enabling AO→CORE callbacks via internal DNS.
- **AO_CALLBACK_URL normalized**: Changed from `https://${aws_lb.gaze.dns_name}/...` (TLS mismatch on ALB hostname) to `http://yclaw-agents.yclaw.internal:3000/api/ao/callback` (Cloud Map internal).
- **Strategist delegation prompt**: `reconcile_pipeline` now includes explicit `event:publish` instructions with correct `payload` field (not `data`) for stale issue re-delegation.

## Files changed

| File | Change |
|------|--------|
| `ao/ao-bridge-server.mjs` | 3-state repo validation in `ensureRepoMirror()` |
| `ao/entrypoint.sh` | Corrupt clone detection + fatal clone failure |
| `packages/core/src/bootstrap/agents.ts` | Spawn try/catch + claim release helper |
| `terraform/main.tf` | CORE Cloud Map service + AO_CALLBACK_URL fix |
| `prompts/strategist-workflow.md` | Delegation rule with correct `payload` field |

## Post-merge ops steps

1. `terraform import aws_service_discovery_service.agents <existing-service-id>` (if CORE Cloud Map was created via CLI)
2. `terraform apply -target=aws_ecs_task_definition.ao -target=aws_service_discovery_service.agents -target=aws_ecs_service.agents`
3. `terraform apply` (full)
4. Force new deployments: `aws ecs update-service --cluster yclaw-cluster-production --service yclaw-ao-production --force-new-deployment`

## Test plan

- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm test` passes (1795/1795 tests)
- [ ] `terraform validate` (requires provider cache — runs in CI)
- [ ] After deploy: trigger Architect on an issue → verify AO spawn succeeds
- [ ] After deploy: force-fail a spawn → verify Redis claim is released (not locked for 2h)
- [ ] After deploy: verify `ao.yclaw.internal` and `yclaw-agents.yclaw.internal` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)