### PR TITLE
fix: review gate CLI args + callback fallback

### DIFF
--- a/ao/ao-bridge-server.mjs
+++ b/ao/ao-bridge-server.mjs
@@ -27,6 +27,7 @@ import {
 const PORT = parseInt(process.env.AO_BRIDGE_PORT || '8420');
 const AUTH_TOKEN = process.env.AO_AUTH_TOKEN;
 const AO_CALLBACK_URL = process.env.AO_CALLBACK_URL || 'http://localhost:3000/api/ao/callback';
+const AO_CALLBACK_FALLBACK_URL = process.env.AO_CALLBACK_FALLBACK_URL || null;
 const MAX_CONCURRENT = parseInt(process.env.AO_MAX_CONCURRENT || '2', 10);
 const MAX_QUEUE = parseInt(process.env.AO_MAX_QUEUE || '100');
 const AO_BIN = process.env.AO_BIN || '/usr/local/bin/ao';
@@ -777,24 +778,25 @@ async function refreshGitHubCliAuth() {
 }
 
 async function postAoCallback(event) {
-  try {
-    console.log(`[ao-bridge] Posting AO callback ${event.type} for session ${event.sessionId || 'unknown'}${event.issueNumber ? ` (#${event.issueNumber})` : ''}`);
-    const res = await fetch(AO_CALLBACK_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-AO-TOKEN': AUTH_TOKEN || '',
-      },
-      body: JSON.stringify(event),
-    });
-    if (!res.ok) {
-      console.warn(`[ao-bridge] AO callback failed with HTTP ${res.status} for ${event.type}`);
-    } else {
+  const urls = [AO_CALLBACK_URL, AO_CALLBACK_FALLBACK_URL].filter(Boolean);
+  const body = JSON.stringify(event);
+  const headers = { 'Content-Type': 'application/json', 'X-AO-TOKEN': AUTH_TOKEN || '' };
+
+  for (const url of urls) {
+    try {
+      console.log(`[ao-bridge] Posting AO callback ${event.type} for session ${event.sessionId || 'unknown'}${event.issueNumber ? ` (#${event.issueNumber})` : ''} → ${url}`);
+      const res = await fetch(url, { method: 'POST', headers, body });
+      if (!res.ok) {
+        console.warn(`[ao-bridge] AO callback failed with HTTP ${res.status} for ${event.type} (${url})`);
+        continue;
+      }
       console.log(`[ao-bridge] AO callback delivered for ${event.type}`);
+      return; // success — done
+    } catch (err) {
+      console.warn(`[ao-bridge] AO callback request failed (${url}):`, err?.message || String(err));
     }
-  } catch (err) {
-    console.warn('[ao-bridge] AO callback request failed:', err?.message || String(err));
   }
+  console.error(`[ao-bridge] AO callback FAILED for ${event.type} — all URLs exhausted`);
 }
 
 async function runTrackedHarvest(meta, reason) {

--- a/ao/review-gate.mjs
+++ b/ao/review-gate.mjs
@@ -11,7 +11,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -135,6 +135,20 @@ export async function runCodexReview(worktreePath, baseBranch, issueNumber) {
   try { unlinkSync(outputFile); } catch { /* ok */ }
 
   const customPrompt = loadReviewPrompt();
+
+  // Codex CLI does not allow a positional [PROMPT] when --base is used.
+  // Write the custom prompt to .codex/instructions.md in the worktree so Codex
+  // picks it up automatically as project-level instructions.
+  if (customPrompt) {
+    try {
+      const instrDir = join(worktreePath, '.codex');
+      mkdirSync(instrDir, { recursive: true });
+      writeFileSync(join(instrDir, 'instructions.md'), customPrompt + '\n');
+    } catch (err) {
+      console.warn(`[review-gate] Failed to write .codex/instructions.md: ${err?.message}`);
+    }
+  }
+
   const args = [
     'exec', 'review',
     '--json',
@@ -143,9 +157,6 @@ export async function runCodexReview(worktreePath, baseBranch, issueNumber) {
     '--full-auto',
     '--output-last-message', outputFile,
   ];
-  if (customPrompt) {
-    args.push(customPrompt);
-  }
 
   console.log(`[review-gate] Running Codex review for #${issueNumber || '?'} against ${baseBranch}`);
   const startMs = Date.now();

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -892,6 +892,7 @@ resource "aws_ecs_task_definition" "ao" {
         { name = "YCLAW_REPOS", value = "YClawAI/YClaw" },
         { name = "YCLAW_AO_OVERLAY_REPO", value = "YClawAI/YClaw" },
         { name = "AO_CALLBACK_URL", value = "http://yclaw-agents.yclaw.internal:3000/api/ao/callback" },
+        { name = "AO_CALLBACK_FALLBACK_URL", value = "https://agents.yclaw.ai/api/ao/callback" },
       ]
 
       secrets = [


### PR DESCRIPTION
## Changes

### 1. Review Gate — Codex CLI argument fix
Codex CLI rejects `--base <BRANCH>` + positional `[PROMPT]`. Fix: write custom prompt to `.codex/instructions.md` in worktree instead.

### 2. AO Callback — Fallback URL support
Cloud Map DNS (`yclaw-agents.yclaw.internal`) not resolving → callback silently fails. Fix: try Cloud Map first, fall back to public ALB URL.

### 3. Terraform
Added `AO_CALLBACK_FALLBACK_URL` env var → `https://agents.yclaw.ai/api/ao/callback`