### PR TITLE
fix: debug logging + belt-and-suspenders Discord channel enforcement

### DIFF
--- a/packages/core/src/actions/discord.ts
+++ b/packages/core/src/actions/discord.ts
@@ -414,10 +414,27 @@ export class DiscordExecutor implements ActionExecutor {
   // ─── Actions ────────────────────────────────────────────────────────────
 
   private async postMessage(params: Record<string, unknown>): Promise<ActionResult> {
-    const channelInput = params.channel as string | undefined;
+    let channelInput = params.channel as string | undefined;
     const text = params.text as string | undefined;
     const replyToMessageId = params.replyToMessageId as string | undefined;
     const agentName = (params.agentName as string | undefined) ?? 'system';
+
+    // Belt-and-suspenders: enforce department channel routing inside DiscordExecutor.
+    // This catches cases where the executor-level enforcement didn't stick.
+    if (agentName && agentName !== 'system') {
+      const SUPPORT_AGENTS = ['keeper', 'guide'];
+      if (!SUPPORT_AGENTS.includes(agentName)) {
+        const deptChannel = getChannelForAgent(agentName, 'discord');
+        if (deptChannel && channelInput !== deptChannel) {
+          logger.info('[discord-executor-enforcement] overriding channel', {
+            agentName,
+            from: channelInput,
+            to: deptChannel,
+          });
+          channelInput = deptChannel;
+        }
+      }
+    }
 
     if (!channelInput || !text) {
       return { success: false, error: 'Missing required parameters: channel, text' };

--- a/packages/core/src/agent/executor.ts
+++ b/packages/core/src/agent/executor.ts
@@ -1048,6 +1048,16 @@ export class AgentExecutor {
       const SUPPORT_AGENTS = ['keeper', 'guide'];
       const departmentChannel = getRoutingChannelForAgent(config.name, 'discord');
 
+      agentLogger.info('[discord-enforcement] check', {
+        actionName,
+        agentName: config.name,
+        departmentChannel,
+        argsChannel: args.channel,
+        argsChannelId: (args as any).channelId,
+        argsKeys: Object.keys(args),
+        isFrozen: Object.isFrozen(args),
+      });
+
       if (SUPPORT_AGENTS.includes(config.name)) {
         // Support agents: allow posting in support-related channels, otherwise force department
         const supportChannelId = getRoutingChannelForAgent('keeper', 'discord');
@@ -1065,14 +1075,29 @@ export class AgentExecutor {
       } else {
         // All other agents: force department channel, ignore LLM's choice
         if (departmentChannel) {
+          // Override both `channel` and `channelId` — LLM may use either field name
           args.channel = departmentChannel;
+          (args as any).channelId = departmentChannel;
+          agentLogger.info('[discord-enforcement] overrode channel', {
+            agentName: config.name,
+            forcedTo: departmentChannel,
+          });
         } else {
+          agentLogger.error('[discord-enforcement] no department channel!', {
+            agentName: config.name,
+            envDev: process.env.DISCORD_CHANNEL_DEVELOPMENT,
+          });
           return {
             success: false,
             error: `No department channel configured for agent ${config.name}. Cannot post to Discord.`,
           };
         }
       }
+
+      agentLogger.info('[discord-enforcement] final args', {
+        channel: args.channel,
+        channelId: (args as any).channelId,
+      });
     }
 
     // Dedup read-only actions within a single execution (e.g., github:get_contents)


### PR DESCRIPTION
## Problem
Architect agent is posting to #general instead of #development despite executor-level channel enforcement code being deployed.

## Council Analysis (4/4 unanimous)
- The enforcement code in executor.ts should work but logs prove the override isn't reaching DiscordExecutor
- Top theories: args object mutation lost, field name mismatch (channel vs channelId), or bypass path
- All 4 models recommend: debug logging + enforcement inside DiscordExecutor as final trust boundary

## Changes

### 1. Debug logging in executor.ts
Logs before/after enforcement: agent name, department channel resolution, args.channel, args.channelId, Object.keys(args), Object.isFrozen(args)

### 2. Belt-and-suspenders in DiscordExecutor (discord.ts)
Hard enforcement inside `postMessage()` — if agent is not support, override channel to department channel. This is the **final trust boundary** that catches all code paths.

### 3. Override both field names
Sets both `args.channel` and `args.channelId` in executor enforcement in case LLM uses the wrong field name.

## Test Plan
After deploy:
1. Trigger Architect with test task
2. Check CloudWatch for `[discord-enforcement]` logs
3. Verify message lands in #development, not #general
4. If belt-and-suspenders catches it, `[discord-executor-enforcement]` log will show