### PR TITLE
fix: deep debug logging for Discord channel resolution mystery

### DIFF
--- a/packages/core/src/actions/discord.ts
+++ b/packages/core/src/actions/discord.ts
@@ -260,14 +260,24 @@ export class DiscordExecutor implements ActionExecutor {
    */
   resolveChannelId(input: string): string {
     const trimmed = input.trim();
+    logger.info('[resolveChannelId] input', { raw: input, trimmed });
     // 1. Try env-var-based routing first (DISCORD_CHANNEL_<DEPT>)
     const fromEnv = getChannelForDepartment(trimmed as Department, 'discord');
-    if (fromEnv) return fromEnv;
+    if (fromEnv) {
+      logger.info('[resolveChannelId] matched env dept', { trimmed, fromEnv });
+      return fromEnv;
+    }
     // 2. Try as agent name → department → channel
     const fromAgent = getChannelForAgent(trimmed, 'discord');
-    if (fromAgent) return fromAgent;
+    if (fromAgent) {
+      logger.info('[resolveChannelId] matched agent', { trimmed, fromAgent });
+      return fromAgent;
+    }
     // 3. Raw Discord snowflake
-    if (/^\d{17,20}$/.test(trimmed)) return trimmed;
+    if (/^\d{17,20}$/.test(trimmed)) {
+      logger.info('[resolveChannelId] raw snowflake', { trimmed });
+      return trimmed;
+    }
     // 4. Last resort: try general channel
     const general = getChannelForDepartment('general', 'discord');
     if (general) {
@@ -414,6 +424,12 @@ export class DiscordExecutor implements ActionExecutor {
   // ─── Actions ────────────────────────────────────────────────────────────
 
   private async postMessage(params: Record<string, unknown>): Promise<ActionResult> {
+    logger.info('[postMessage] raw params received', {
+      channel: params.channel,
+      channelId: (params as any).channelId,
+      agentName: params.agentName,
+      keys: Object.keys(params),
+    });
     let channelInput = params.channel as string | undefined;
     const text = params.text as string | undefined;
     const replyToMessageId = params.replyToMessageId as string | undefined;


### PR DESCRIPTION
## Context
PR #72 added executor-level enforcement + belt-and-suspenders. Test results from production:

```
[discord-enforcement] check     → departmentChannel: 1489421639274729502 ✅
[discord-enforcement] overrode  → forcedTo: 1489421639274729502 ✅
[discord-enforcement] final     → channel: 1489421639274729502, channelId: 1489421639274729502 ✅
[discord-executor]   Posting    → channelId: 1489421589941325904 ❌ GENERAL
```

The executor enforcement IS running and IS overriding args.channel correctly.
But somewhere between the enforcement and the discord-executor log, the channel reverts to general.

## This PR adds
- `[postMessage] raw params received` — logs exactly what params arrive at postMessage entry
- `[resolveChannelId]` — logs which resolution step matched (env dept, agent, snowflake, or fallback)

One deploy + one test will tell us definitively where the channel flip happens.