### PR TITLE
fix: unblock Discord agent message delivery

### DIFF
--- a/packages/core/src/actions/discord.ts
+++ b/packages/core/src/actions/discord.ts
@@ -25,9 +25,9 @@ const logger = createLogger('discord-executor');
 //   DISCORD_BOT_TOKEN — Discord bot token (read by DiscordChannelAdapter)
 //
 // Guardrails (all MUST be enforced):
-//   - 90s per-channel cooldown per agent, 30s per-thread cooldown per agent
+//   - 30s per-channel cooldown per agent, 15s per-thread cooldown per agent
 //   - 20 messages/hour/agent global cap
-//   - 600 char max on public-channel messages (threads exempt)
+//   - 2000 char max on public-channel messages (Discord's native limit)
 //   - Dedup fingerprinting (1h window, copied from SlackExecutor)
 //   - No DMs — any user-targeted action is rejected
 //   - Channel resolution: symbolic names in DISCORD_CHANNELS or raw snowflakes
@@ -48,12 +48,12 @@ const logger = createLogger('discord-executor');
 const DEFAULT_HISTORY_LIMIT = 50;
 const MAX_HISTORY_LIMIT = 100;
 
-const PUBLIC_MESSAGE_MAX_LEN = 600;
+const PUBLIC_MESSAGE_MAX_LEN = 2000;
 
 /** Per-agent, per-channel cooldown for top-level messages (seconds). */
-const CHANNEL_COOLDOWN_S = 90;
+const CHANNEL_COOLDOWN_S = 30;
 /** Per-agent, per-thread cooldown for thread replies (seconds). */
-const THREAD_COOLDOWN_S = 30;
+const THREAD_COOLDOWN_S = 15;
 /** Global per-agent hourly cap. */
 const HOURLY_CAP = 20;
 const HOURLY_WINDOW_S = 3600;
@@ -151,10 +151,10 @@ export class DiscordExecutor implements ActionExecutor {
     return [
       {
         name: 'discord:message',
-        description: 'Post a message to a Discord channel (max 600 chars). Use a thread for longer replies.',
+        description: 'Post a message to a Discord channel (max 2000 chars).',
         parameters: {
           channel: { type: 'string', description: 'Channel name from DISCORD_CHANNELS (e.g. "support") or raw snowflake ID. Omit to use department default.' },
-          text: { type: 'string', description: 'Message content (max 600 characters in public channels)', required: true },
+          text: { type: 'string', description: 'Message content (max 2000 characters)', required: true },
           replyToMessageId: { type: 'string', description: 'Optional message ID to reply to' },
           agentName: { type: 'string', description: 'Agent identity key for display name override (e.g. "keeper")' },
         },
@@ -205,7 +205,7 @@ export class DiscordExecutor implements ActionExecutor {
       },
       {
         name: 'discord:alert',
-        description: 'Post an alert message (colored embed) to a Discord channel. Bypasses the 600-char public limit since alerts use an embed body.',
+        description: 'Post an alert message (colored embed) to a Discord channel.',
         parameters: {
           channel: { type: 'string', description: 'Channel name or snowflake', required: true },
           text: { type: 'string', description: 'Alert body text', required: true },

--- a/packages/core/tests/discord-executor.test.ts
+++ b/packages/core/tests/discord-executor.test.ts
@@ -176,16 +176,26 @@ describe('DiscordExecutor', () => {
     expect(noText.error).toMatch(/text/);
   });
 
-  it('discord:message rejects text over 600 characters', async () => {
-    const long = 'x'.repeat(601);
+  it('discord:message rejects text over 2000 characters', async () => {
+    const long = 'x'.repeat(2001);
     const result = await executor.execute('message', {
       channel: 'general',
       text: long,
       agentName: 'keeper',
     });
     expect(result.success).toBe(false);
-    expect(result.error).toContain('600 character limit');
+    expect(result.error).toContain('2000 character limit');
     expect(adapter.send).not.toHaveBeenCalled();
+  });
+
+  it('discord:message allows text up to 2000 characters', async () => {
+    const text = 'x'.repeat(1999);
+    const result = await executor.execute('message', {
+      channel: 'general',
+      text,
+      agentName: 'system',
+    });
+    expect(result.success).toBe(true);
   });
 
   it('discord:message accepts symbolic department channel names via env-var routing', async () => {
@@ -318,7 +328,7 @@ describe('DiscordExecutor', () => {
     expect([...redis._store.keys()].some((k) => bucketKeyPattern.test(k))).toBe(true);
   });
 
-  it('thread_reply allows long text (no 600 char limit)', async () => {
+  it('thread_reply allows long text (no channel char limit)', async () => {
     const long = 'x'.repeat(1500);
     const result = await executor.execute('thread_reply', {
       channel: 'support',


### PR DESCRIPTION
## Problem
Smoke test with 5 real agent tasks revealed that agent work output is NOT appearing in Discord. The routing fix (PR #77) works — messages go to correct channels — but the delivery pipeline blocks them:

- **600-char limit** rejects every real work output (assessments, reviews, drafts)
- **90s cooldown** prevents retries after failures
- Agents try thread fallback → threads fail → rate limited → nothing gets through

Only lifecycle embeds (Started/Completed) from ChannelNotifier appear because they bypass these guardrails.

## Council Review (4/4 unanimous)

### Change 1: Char limit 600 → 2000
Discord's native limit is 2000. The 600-char guardrail from PR #70 was too aggressive — it blocks all real agent work product. Council unanimous: raise to match Discord's actual limit.

> *"This single change will likely allow 80% of your agent messages to pass through"* — GPT-5.4

### Change 2: Channel cooldown 90s → 30s, Thread cooldown 30s → 15s
Agents doing real work need to post within a single task execution window. 90s made it impossible to retry after transient failures or post summary + detail.

> *"Allow burst of 2-3 messages, reduce cooldown to 15-30s, exempt thread replies"* — All 4 models

### Change 3: Updated tool descriptions + tests
- Tool descriptions no longer advertise 600-char limit
- Tests validate the 2000-char boundary
- New test: messages up to 2000 chars accepted

## Phase 2 (deferred)
- Auto-thread overflow for >2000 char content
- Webhook thread_id fix (use `?thread_id=` on parent webhook)
- Smart executor that abstracts transport from agents

## Test Plan
After deploy: re-trigger 5 real agent tasks, verify content appears in Discord channels