### PR TITLE
fix: restore Architect pipeline crons and remove Strategist reconcile workaround

### DIFF
--- a/departments/development/architect.yaml
+++ b/departments/development/architect.yaml
@@ -43,6 +43,29 @@ triggers:
   - type: cron
     schedule: "0 20 * * 0"
     task: tech_debt_scan
+
+  # Stale issue sweep — catches issues missed by real-time event triggers
+  # Removes stale in-progress labels, delegates eligible unworked issues to AO
+  - type: cron
+    schedule: "*/30 * * * *"
+    task: stale_issue_sweep
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      maxTokens: 4096
+      temperature: 0.2
+
+  # Pipeline health scan — ensures all repos have CI, infra, branch protection
+  - type: cron
+    schedule: "30 */3 * * *"
+    task: pipeline_health_scan
+    description: "Scan all registered repos for missing pipeline components"
+    model:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      maxTokens: 4096
+      temperature: 0.2
+
   - type: event
     event: strategist:architect_directive
     task: architecture_directive
@@ -109,6 +132,7 @@ actions:
   - github:pr_comment
   - github:add_labels
   - github:remove_label
+  - ao:status
   - repo:list
   - vault:read
   - vault:search

--- a/departments/executive/strategist.yaml
+++ b/departments/executive/strategist.yaml
@@ -63,16 +63,6 @@ triggers:
       model: claude-opus-4-6
       temperature: 0.5
       maxTokens: 8192
-  # Model Review Apr 2026: downgraded from Sonnet to Haiku — mechanical triage task
-  - type: cron
-    schedule: '*/10 * * * *'
-    task: reconcile_pipeline
-    description: "Run PR/Issue reconciliation loop"
-    model:
-      provider: anthropic
-      model: claude-haiku-4-5
-      temperature: 0.2
-      maxTokens: 4096
   - type: event
     event: claudeception:reflect
     task: self_reflection

--- a/packages/core/src/actions/ao.ts
+++ b/packages/core/src/actions/ao.ts
@@ -1,0 +1,103 @@
+import type { ActionResult, ActionExecutor } from './types.js';
+import type { ToolDefinition } from '../config/schema.js';
+import { createLogger } from '../logging/logger.js';
+
+const logger = createLogger('ao-executor');
+
+const DEFAULT_SERVICE_URL = 'http://ao.yclaw.internal:8420';
+const STATUS_TIMEOUT_MS = 5_000;
+
+// ─── AO Action Executor ────────────────────────────────────────────────────
+//
+// Actions:
+//   ao:status — Check AO service health and queue depth
+//
+// Used by Architect's stale_issue_sweep to gate delegation on AO availability.
+//
+
+export class AoExecutor implements ActionExecutor {
+  readonly name = 'ao';
+  private readonly serviceUrl: string;
+
+  constructor() {
+    this.serviceUrl = process.env.AO_SERVICE_URL || DEFAULT_SERVICE_URL;
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'ao:status',
+        description:
+          'Check AO (Agent Orchestrator) health and queue depth. Returns available (boolean), queue_depth (number or null), and any open circuit breakers.',
+        parameters: {},
+      },
+    ];
+  }
+
+  async execute(
+    action: string,
+    _params: Record<string, unknown>,
+  ): Promise<ActionResult> {
+    switch (action) {
+      case 'status':
+        return this.getStatus();
+      default:
+        return { success: false, error: `Unknown ao action: ${action}` };
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return this.isAvailable();
+  }
+
+  // ─── Private ──────────────────────────────────────────────────────────────
+
+  private async getStatus(): Promise<ActionResult> {
+    const available = await this.isAvailable();
+
+    // Try /status for queue depth (best-effort — endpoint may not exist)
+    let queueDepth: number | null = null;
+    let degraded = false;
+
+    if (available) {
+      try {
+        const response = await fetch(`${this.serviceUrl}/status`, {
+          signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+        });
+        if (response.ok) {
+          const body = (await response.json()) as Record<string, unknown>;
+          if (typeof body.queue_depth === 'number') {
+            queueDepth = body.queue_depth;
+          }
+          if (body.degraded === true) {
+            degraded = true;
+          }
+        }
+      } catch {
+        // /status endpoint may not exist — that's fine, health is enough
+        logger.debug('AO /status endpoint unavailable — queue depth unknown');
+      }
+    }
+
+    return {
+      success: true,
+      data: {
+        available,
+        degraded,
+        queue_depth: queueDepth,
+        service_url: this.serviceUrl,
+      },
+    };
+  }
+
+  private async isAvailable(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.serviceUrl}/health`, {
+        signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/core/src/bootstrap/actions.ts
+++ b/packages/core/src/bootstrap/actions.ts
@@ -16,6 +16,7 @@ import { GitHubExecutor } from '../actions/github/index.js';
 import { EmailExecutor } from '../actions/email.js';
 import { EventActionExecutor } from '../actions/event.js';
 import { CodegenExecutor } from '../actions/codegen.js';
+import { AoExecutor } from '../actions/ao.js';
 import { DeployExecutor } from '../actions/deploy/index.js';
 import { RepoExecutor } from '../actions/repo.js';
 import { XSearchExecutor } from '../actions/x-search.js';
@@ -100,6 +101,7 @@ export async function initActions(services: ServiceContext): Promise<ActionConte
   actionRegistry.register('email', new EmailExecutor());
   actionRegistry.register('event', new EventActionExecutor(eventBus));
   actionRegistry.register('codegen', new CodegenExecutor(auditLog, repoRegistry));
+  actionRegistry.register('ao', new AoExecutor());
   actionRegistry.register('deploy', new DeployExecutor(auditLog, repoRegistry, outboundSafety, eventBus, deployRedis ?? undefined));
   actionRegistry.register('repo', new RepoExecutor(repoRegistry));
   actionRegistry.register('x', new XSearchExecutor());

--- a/prompts/architect-workflow.md
+++ b/prompts/architect-workflow.md
@@ -640,7 +640,7 @@ Safety-net sweep. Catches issues that were missed by the real-time event trigger
 
 ### Steps
 
-1. Call `codegen:status`. If AO is degraded, queue depth > 5, or unavailable, stop immediately. Return "AO not ready, skipping sweep."
+1. Call `ao:status`. If AO is degraded, queue depth > 5, or unavailable, stop immediately. Return "AO not ready, skipping sweep."
 2. Use `repo:list` to get all registered repos. For each healthy repo, call `github:list_issues` with `state: open`.
 3. **Stale in-progress reconciliation:** For any issue labeled `in-progress` that was updated more than 3 hours ago (check `updated_at`), the AO session likely failed without a callback. Remove the `in-progress` label using `github:remove_label` so it becomes eligible again. Log a warning: "Removed stale in-progress from #N (last updated {time})."
 4. For each issue (excluding those still validly `in-progress`), evaluate eligibility using ONLY labels:
@@ -651,7 +651,7 @@ Safety-net sweep. Catches issues that were missed by the real-time event trigger
 6. For each selected issue:
    a. Call `github:get_issue` to fetch full details
    b. Create a structured directive (same format as evaluate_and_delegate: `investigation_summary`, `key_files`, `constraints`, `acceptance_criteria`)
-   c. Publish `architect:build_directive` with all structured fields plus `repo` (full slug: `owner/repo`) and `issueNumber` (integer)
+   c. Publish `architect:build_directive` via `event:publish` with all structured fields plus `repo` (full slug: `owner/repo`) and `issueNumber` (integer)
 7. Report what you did: "Delegated N issues: #X, #Y, #Z" or "No eligible issues found" or "AO not ready, skipping." Include any stale in-progress labels that were removed.
 
 ### Rules
@@ -661,7 +661,7 @@ Safety-net sweep. Catches issues that were missed by the real-time event trigger
 - IGNORE branch existence — you cannot check it
 - If an issue has both an eligible label AND an exclusion label, the exclusion label wins (skip it)
 - If no issues are eligible, that's fine. Return immediately. Don't force delegation.
-- **If no issues were delegated and AO was available, do NOT post to Slack.** Silent sweeps are expected behavior.
+- **If no issues were delegated and AO was available, do NOT post to Discord.** Silent sweeps are expected behavior.
 
 ---
 
@@ -1084,7 +1084,7 @@ For unassigned issues, use `event:publish` to emit `github:issue_assigned` (whic
 
 ### Step 5: Report
 
-Post a summary to Slack #yclaw-development ONLY if gaps were found:
+Post a summary to #yclaw-development via `discord:message` ONLY if gaps were found:
 ```
 🔍 Pipeline Health Scan — {timestamp}
 Repos scanned: {count}

--- a/prompts/strategist-workflow.md
+++ b/prompts/strategist-workflow.md
@@ -11,19 +11,6 @@ Follow the Strategist Heartbeat Protocol (strategist-heartbeat.md). Quick scan c
 
 ---
 
-## Task: reconcile_pipeline (triggered by cron: every 10 min)
-
-Lightweight pipeline reconciliation. Check for:
-1. Open PRs with CI green + approved but not merged → merge them
-2. AO tasks that completed but weren't acknowledged → process callbacks
-3. Issues assigned to agents with no activity in 2+ hours → re-trigger via delegation
-
-**Delegation rule:** When you identify open issues that require code changes and are not currently in-progress (no `in-progress` label, no recent AO spawn), publish a `build_directive` event targeting the Architect using `event:publish` with `{source: 'strategist', type: 'architect_directive', payload: {issue: <number>, repo: '<owner/repo>', task: '<description>'}}`. Do not attempt to fix code yourself — delegate to Architect, who will analyze and delegate to AO/Builder.
-
-Max 3 tool call rounds. If nothing to reconcile, exit silently.
-
----
-
 ## Task: model_review (triggered by cron: first Monday monthly)
 
 Review AI model performance and costs for the past month. Check execution cache stats, token usage patterns, and model effectiveness. Post summary to executive channel with recommendations.


### PR DESCRIPTION
## Summary

- **Add missing cron triggers** to `architect.yaml`: `stale_issue_sweep` (every 30 min) and `pipeline_health_scan` (every 3 hours) — prompts existed in `architect-workflow.md` but were never wired up as triggers
- **Implement `ao:status` action** (`packages/core/src/actions/ao.ts`) — checks AO health via `/health` and queue depth via `/status`. Required by `stale_issue_sweep` to gate delegation on AO availability.
- **Add `ao:status`** to Architect's allowed actions
- **Remove broken `reconcile_pipeline`** cron from `strategist.yaml` (ran every 10 min on Haiku, read issues but never actually delegated to Architect/AO)
- **Remove `reconcile_pipeline` task section** from `strategist-workflow.md`
- **Fix `stale_issue_sweep` prompt**: `codegen:status` → `ao:status`, add explicit `event:publish` reference, fix Slack → Discord
- **Fix `pipeline_health_scan` prompt**: Slack → Discord reference

## Why this works

In Gaze (which works), Architect runs `stale_issue_sweep` every 30 minutes:
1. Checks AO health via `ao:status`
2. Removes stale `in-progress` labels (>3h without update)
3. Finds eligible issues by label
4. Publishes `architect:build_directive` for up to 3 issues
5. AO picks up the directive and starts working

YCLAW had the prompts but not the triggers. The Strategist's `reconcile_pipeline` was a broken workaround — it could read issues but lacked the delegation path (no `architect:build_directive` publish).

## Files changed

| File | Change |
|------|--------|
| `departments/development/architect.yaml` | +2 cron triggers, +1 action (`ao:status`) |
| `departments/executive/strategist.yaml` | -1 cron trigger (`reconcile_pipeline`) |
| `prompts/architect-workflow.md` | Fix `ao:status`, `event:publish`, Slack→Discord |
| `prompts/strategist-workflow.md` | Remove `reconcile_pipeline` task section |
| `packages/core/src/actions/ao.ts` | **NEW** — `AoExecutor` implementing `ao:status` |
| `packages/core/src/bootstrap/actions.ts` | Register `AoExecutor` |

## Remaining `reconcile_pipeline` references

`docs/reports/model-review-2026-04.md` contains historical references to `reconcile_pipeline` in the April 2026 model review report. These are informational/historical and intentionally left as-is.

## Pre-merge manual steps (DO NOT AUTOMATE)

- Remove `🚧 in-progress` label from issues #74, #81, #53

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (111 files, 1798 tests)
- [x] YAML valid (both architect.yaml and strategist.yaml)
- [x] No duplicate cron entries
- [x] Model IDs match existing crons (`claude-sonnet-4-20250514`)
- [x] Zero `reconcile_pipeline` in strategist.yaml and strategist-workflow.md
- [x] `ao:status` action implemented and registered in runtime
- [ ] Deploy and confirm stale_issue_sweep fires on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)