### PR TITLE
feat: dynamic agent routing from YAML configs

### DIFF
--- a/packages/core/src/actions/slack.ts
+++ b/packages/core/src/actions/slack.ts
@@ -33,22 +33,41 @@ const logger = createLogger('slack-executor');
 export { SLACK_CHANNELS } from '../utils/channel-routing.js';
 
 // ─── Agent Identity Map ─────────────────────────────────────────────────────
-// Maps agent name → display identity for Slack messages
+// Derived from AgentRegistry at runtime. Proxied for backward compatibility.
 
-export const AGENT_IDENTITIES: Record<string, { username: string; icon_emoji: string }> = {
-  strategist:  { username: 'Strategist',  icon_emoji: ':chess_pawn:' },
-  reviewer:    { username: 'Reviewer',    icon_emoji: ':mag:' },
-  ember:       { username: 'Ember',       icon_emoji: ':fire:' },
-  scout:       { username: 'Scout',       icon_emoji: ':telescope:' },
-  forge:       { username: 'Forge',       icon_emoji: ':hammer_and_wrench:' },
-  architect:   { username: 'Architect',   icon_emoji: ':building_construction:' },
-  deployer:    { username: 'Deployer',    icon_emoji: ':rocket:' },
-  sentinel:    { username: 'Sentinel',    icon_emoji: ':shield:' },
-  signal:      { username: 'Signal',      icon_emoji: ':satellite:' },
-  keeper:      { username: 'Keeper',      icon_emoji: ':key:' },
-  treasurer:   { username: 'Treasurer',   icon_emoji: ':bank:' },
-  guide:       { username: 'Guide',       icon_emoji: ':compass:' },
-};
+import {
+  getAgentIdentity,
+  getSlackEmoji,
+  getRegisteredAgents,
+  findAgentIdentity,
+} from '../notifications/AgentRegistry.js';
+
+export const AGENT_IDENTITIES: Record<string, { username: string; icon_emoji: string }> = new Proxy(
+  {} as Record<string, { username: string; icon_emoji: string }>,
+  {
+    get: (_t, prop) => {
+      if (typeof prop === 'symbol') return undefined;
+      const ident = findAgentIdentity(prop);
+      if (!ident) return undefined;
+      return { username: ident.name, icon_emoji: getSlackEmoji(prop) };
+    },
+    has: (_t, prop) => {
+      if (typeof prop === 'symbol') return false;
+      return !!findAgentIdentity(prop);
+    },
+    ownKeys: () => getRegisteredAgents(),
+    getOwnPropertyDescriptor: (_t, prop) => {
+      if (typeof prop === 'symbol') return undefined;
+      const ident = findAgentIdentity(prop as string);
+      if (!ident) return undefined;
+      return {
+        configurable: true,
+        enumerable: true,
+        value: { username: ident.name, icon_emoji: getSlackEmoji(prop as string) },
+      };
+    },
+  },
+);
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 

--- a/packages/core/src/bootstrap/agents.ts
+++ b/packages/core/src/bootstrap/agents.ts
@@ -5,6 +5,7 @@ import { StaleLoopDetector } from '../objectives/stale-loop-detector.js';
 import { RevisionTracker } from '../config-revisions/revision-tracker.js';
 import { AgentExecutor } from '../agent/executor.js';
 import { AgentRouter } from '../agent/router.js';
+import { initAgentRegistry } from '../notifications/AgentRegistry.js';
 import { SLACK_CHANNELS } from '../actions/slack.js';
 import type { SlackExecutor } from '../actions/slack.js';
 import type { GitHubExecutor } from '../actions/github/index.js';
@@ -252,6 +253,12 @@ export async function initAgents(
   // ─── Agent Router ────────────────────────────────────────────────────
   const router = new AgentRouter();
   executor.setRouter(router);
+
+  // ─── Agent Registry (identity/routing) ─────────────────────────────
+  // Must run before any listeners, webhook consumers, or event bus
+  // subscriptions that depend on agent identity or channel routing.
+  initAgentRegistry(router.getAllConfigs());
+  logger.info('Agent identity registry initialized from YAML configs');
 
   // ─── Deploy Config Capture ──────────────────────────────────────────
   // After loading all configs, check for changes vs stored revisions

--- a/packages/core/src/modules/journaler.ts
+++ b/packages/core/src/modules/journaler.ts
@@ -8,6 +8,7 @@ import type {
 } from '../types/events.js';
 import { createLogger } from '../logging/logger.js';
 import { GITHUB_ORG_DEFAULTS } from '../config/github-defaults.js';
+import { getAgentEmoji } from '../utils/channel-routing.js';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -43,24 +44,6 @@ const NOISE_TYPES = new Set([
   'coord.task.accepted',
   'coord.task.started',
 ]);
-
-// ─── Agent Emoji Map ────────────────────────────────────────────────────────
-
-const AGENT_EMOJI: Record<string, string> = {
-  strategist: '\u{1F9E0}',  // 🧠
-  builder: '\u{1F6E0}\uFE0F', // 🛠️
-  architect: '\u{1F4D0}',   // 📐
-  designer: '\u{1F3A8}',    // 🎨
-  deployer: '\u{1F680}',    // 🚀
-  reviewer: '\u{1F4CB}',    // 📋
-  scout: '\u{1F50D}',       // 🔍
-  ember: '\u{1F525}',       // 🔥
-  forge: '\u2692\uFE0F',    // ⚒️
-  sentinel: '\u{1F6E1}\uFE0F', // 🛡️
-  treasurer: '\u{1F4B0}',   // 💰
-  keeper: '\u{1F3E0}',      // 🏠
-  guide: '\u{1F4DA}',       // 📚
-};
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -293,7 +276,7 @@ export class Journaler {
 /** Format a YClawEvent into a Markdown GitHub comment. */
 export function formatComment(event: YClawEvent<unknown>): string {
   const source = event.source || 'system';
-  const emoji = AGENT_EMOJI[source] || '\u{1F514}'; // 🔔
+  const emoji = getAgentEmoji(source);
   const agentName = source.charAt(0).toUpperCase() + source.slice(1);
   const action = describeAction(event);
   const payload = event.payload as Record<string, unknown>;

--- a/packages/core/src/notifications/AgentRegistry.ts
+++ b/packages/core/src/notifications/AgentRegistry.ts
@@ -1,14 +1,17 @@
 /**
- * AgentRegistry — Agent identity metadata for notifications.
+ * AgentRegistry — Single source of truth for agent identity/routing.
  *
- * Centralizes agent display information (emoji, color, department, avatar)
- * so both Slack and Discord renderers produce consistent agent identity.
- * Extends the existing AGENT_EMOJI and AGENT_DEPARTMENT maps in
- * channel-routing.ts with richer metadata needed for Discord embeds
- * and webhook identity.
+ * Populated at bootstrap from agent YAML configs via initAgentRegistry().
+ * When a new agent YAML is added to departments/, routing and identity
+ * Just Work — no code changes needed.
+ *
+ * Display overrides (emoji, color, avatar) live here because they are NOT
+ * part of the YAML schema. Everything else (name, department) comes from
+ * the loaded AgentConfig objects.
  */
 
 import type { Department } from './types.js';
+import type { AgentConfig } from '../config/schema.js';
 
 export interface AgentIdentity {
   id: string;
@@ -21,26 +24,89 @@ export interface AgentIdentity {
   avatarUrl?: string;
 }
 
-export const AGENT_REGISTRY: Record<string, AgentIdentity> = {
-  strategist:  { id: 'strategist',  name: 'Strategist',  emoji: '\u{1F9E0}',       department: 'executive',   color: 0x7C3AED },
-  architect:   { id: 'architect',   name: 'Architect',    emoji: '\u{1F3D7}\uFE0F', department: 'development', color: 0x2563EB },
-  builder:     { id: 'builder',     name: 'Builder',      emoji: '\u{1F6E0}\uFE0F', department: 'development', color: 0x6366F1 },
-  deployer:    { id: 'deployer',    name: 'Deployer',     emoji: '\u{1F680}',       department: 'development', color: 0x0891B2 },
-  designer:    { id: 'designer',    name: 'Designer',     emoji: '\u{1F3A8}',       department: 'development', color: 0xEC4899 },
-  reviewer:    { id: 'reviewer',    name: 'Reviewer',     emoji: '\u{1F50D}',       department: 'executive',   color: 0x059669 },
-  ember:       { id: 'ember',       name: 'Ember',        emoji: '\u{1F525}',       department: 'marketing',   color: 0xF97316 },
-  treasurer:   { id: 'treasurer',   name: 'Treasurer',    emoji: '\u{1F4B0}',       department: 'finance',     color: 0xEAB308 },
-  scout:       { id: 'scout',       name: 'Scout',        emoji: '\u{1F52D}',       department: 'marketing',   color: 0x8B5CF6 },
-  keeper:      { id: 'keeper',      name: 'Keeper',       emoji: '\u{1F6E1}\uFE0F', department: 'support',     color: 0x0EA5E9 },
-  sentinel:    { id: 'sentinel',    name: 'Sentinel',     emoji: '\u{1F510}',       department: 'operations',  color: 0xDC2626 },
-  forge:       { id: 'forge',       name: 'Forge',        emoji: '\u2692\uFE0F',    department: 'marketing',   color: 0x78716C },
-  guide:       { id: 'guide',       name: 'Guide',        emoji: '\u{1F4D8}',       department: 'support',     color: 0x0284C7 },
-  signal:      { id: 'signal',      name: 'Signal',       emoji: '\u{1F4CA}',       department: 'operations',  color: 0x6366F1 },
+// ─── Display Overrides ──────────────────────────────────────────────────────
+// Optional enrichments for known agents. If an agent isn't here, it gets
+// defaults (🔔 emoji, grey color).
+
+const DISPLAY_OVERRIDES: Record<string, Partial<Pick<AgentIdentity, 'emoji' | 'color' | 'avatarUrl'>>> = {
+  strategist:  { emoji: '\u{1F9E0}',       color: 0x7C3AED }, // 🧠
+  architect:   { emoji: '\u{1F3D7}\uFE0F', color: 0x2563EB }, // 🏗️
+  designer:    { emoji: '\u{1F3A8}',        color: 0xEC4899 }, // 🎨
+  reviewer:    { emoji: '\u{1F50D}',        color: 0x059669 }, // 🔍
+  ember:       { emoji: '\u{1F525}',        color: 0xF97316 }, // 🔥
+  treasurer:   { emoji: '\u{1F4B0}',        color: 0xEAB308 }, // 💰
+  scout:       { emoji: '\u{1F52D}',        color: 0x8B5CF6 }, // 🔭
+  keeper:      { emoji: '\u{1F6E1}\uFE0F',  color: 0x0EA5E9 }, // 🛡️
+  sentinel:    { emoji: '\u{1F510}',        color: 0xDC2626 }, // 🔐
+  forge:       { emoji: '\u2692\uFE0F',     color: 0x78716C }, // ⚒️
+  guide:       { emoji: '\u{1F4D8}',        color: 0x0284C7 }, // 📘
+  signal:      { emoji: '\u{1F4CA}',        color: 0x6366F1 }, // 📊
+  librarian:   { emoji: '\u{1F4DA}',        color: 0x8B5CF6 }, // 📚
+  mechanic:    { emoji: '\u{1F527}',        color: 0x475569 }, // 🔧
 };
+
+// Slack-specific emoji names (cannot use Unicode in Slack's icon_emoji field)
+const SLACK_EMOJI_OVERRIDES: Record<string, string> = {
+  strategist: ':chess_pawn:',
+  reviewer:   ':mag:',
+  ember:      ':fire:',
+  scout:      ':telescope:',
+  forge:      ':hammer_and_wrench:',
+  architect:  ':building_construction:',
+  sentinel:   ':shield:',
+  signal:     ':satellite:',
+  keeper:     ':key:',
+  treasurer:  ':bank:',
+  guide:      ':compass:',
+  designer:   ':art:',
+  librarian:  ':books:',
+  mechanic:   ':wrench:',
+};
+
+// ─── Mutable Registry ───────────────────────────────────────────────────────
+
+const registry = new Map<string, AgentIdentity>();
+let initialized = false;
+
+function assertInitialized(): void {
+  if (!initialized) {
+    throw new Error(
+      'AgentRegistry accessed before initAgentRegistry() was called. Fix bootstrap ordering.',
+    );
+  }
+}
+
+/**
+ * Populate the registry from loaded AgentConfig objects.
+ * Called once at bootstrap after loadAllAgentConfigs().
+ * MUST run before any routing, Discord listeners, or event consumers start.
+ */
+export function initAgentRegistry(configs: Map<string, AgentConfig>): void {
+  registry.clear();
+  for (const [name, config] of configs) {
+    const overrides = DISPLAY_OVERRIDES[name] ?? {};
+    registry.set(name, {
+      id: name,
+      name: name.charAt(0).toUpperCase() + name.slice(1),
+      emoji: overrides.emoji ?? '\u{1F514}', // 🔔
+      department: config.department as Department,
+      color: overrides.color ?? 0x6B7280,
+      avatarUrl: overrides.avatarUrl,
+    });
+  }
+  initialized = true;
+}
+
+/** Strict lookup — returns undefined if agent not registered. */
+export function findAgentIdentity(agentId: string): AgentIdentity | undefined {
+  assertInitialized();
+  return registry.get(agentId);
+}
 
 /** Look up agent identity. Returns a generic fallback for unknown agents. */
 export function getAgentIdentity(agentId: string): AgentIdentity {
-  return AGENT_REGISTRY[agentId] ?? {
+  assertInitialized();
+  return registry.get(agentId) ?? {
     id: agentId,
     name: agentId.charAt(0).toUpperCase() + agentId.slice(1),
     emoji: '\u{1F514}', // 🔔
@@ -48,3 +114,47 @@ export function getAgentIdentity(agentId: string): AgentIdentity {
     color: 0x6B7280,
   };
 }
+
+/** Get all registered agent IDs. */
+export function getRegisteredAgents(): string[] {
+  assertInitialized();
+  return [...registry.keys()];
+}
+
+/** Get Slack-specific emoji name for an agent. */
+export function getSlackEmoji(agentId: string): string {
+  return SLACK_EMOJI_OVERRIDES[agentId] ?? ':bell:';
+}
+
+/** Reset for tests only. */
+export function resetAgentRegistryForTests(): void {
+  registry.clear();
+  initialized = false;
+}
+
+// ─── Backward-Compatible Export ─────────────────────────────────────────────
+// Proxied object so existing code that imports AGENT_REGISTRY as a record
+// continues to work. Implements full trap set so Object.keys() etc. work.
+
+/** @deprecated Use getAgentIdentity() instead */
+export const AGENT_REGISTRY: Record<string, AgentIdentity> = new Proxy(
+  {} as Record<string, AgentIdentity>,
+  {
+    get: (_target, prop) => {
+      if (typeof prop === 'symbol') return undefined;
+      return findAgentIdentity(prop);
+    },
+    has: (_target, prop) => {
+      if (typeof prop === 'symbol') return false;
+      return registry.has(prop);
+    },
+    ownKeys: () => [...registry.keys()],
+    getOwnPropertyDescriptor: (_target, prop) => {
+      if (typeof prop === 'symbol') return undefined;
+      const val = registry.get(prop as string);
+      return val
+        ? { configurable: true, enumerable: true, value: val }
+        : undefined;
+    },
+  },
+);

--- a/packages/core/src/utils/channel-routing.ts
+++ b/packages/core/src/utils/channel-routing.ts
@@ -1,9 +1,9 @@
 /**
  * channel-routing — Platform-agnostic department/channel routing.
  *
- * Replaces the hardcoded DEPARTMENT_CHANNEL map in slack-blocks.ts. Every
- * channel notifier (Slack, Discord, Telegram, …) resolves an agent name to
- * a platform-specific channel ID through `getChannelForAgent(agent, platform)`.
+ * Agent identity (emoji, department) is derived from the AgentRegistry,
+ * which is populated at bootstrap from agent YAML configs. When a new
+ * agent YAML is added, routing Just Works — no code changes needed.
  *
  * Channel IDs are loaded from environment variables so operators can wire
  * the same agent to different channels on different platforms without
@@ -23,50 +23,11 @@
  * if general is also unset).
  */
 
-// ─── Agent Emoji Map ────────────────────────────────────────────────────────
-
-/**
- * Agent → emoji for notification headers. Used by both Slack Block Kit
- * and Discord markdown formatters.
- */
-export const AGENT_EMOJI: Record<string, string> = {
-  strategist: '\u{1F9E0}',       // 🧠
-  builder: '\u{1F6E0}\uFE0F',    // 🛠️
-  architect: '\u{1F4D0}',        // 📐
-  designer: '\u{1F3A8}',         // 🎨
-  deployer: '\u{1F680}',         // 🚀
-  reviewer: '\u{1F4CB}',         // 📋
-  scout: '\u{1F50D}',            // 🔍
-  ember: '\u{1F525}',            // 🔥
-  forge: '\u2692\uFE0F',         // ⚒️
-  sentinel: '\u{1F6E1}\uFE0F',   // 🛡️
-  treasurer: '\u{1F4B0}',        // 💰
-  keeper: '\u{1F3E0}',           // 🏠
-  guide: '\u{1F4DA}',            // 📚
-  signal: '\u{1F4E1}',           // 📡
-};
-
-// ─── Agent → Department Mapping ─────────────────────────────────────────────
-
-/**
- * Agent → department routing. One source of truth for every notifier.
- */
-export const AGENT_DEPARTMENT: Record<string, string> = {
-  strategist: 'executive',
-  reviewer: 'executive',
-  architect: 'development',
-  builder: 'development',
-  deployer: 'development',
-  designer: 'development',
-  ember: 'marketing',
-  forge: 'marketing',
-  scout: 'marketing',
-  sentinel: 'operations',
-  signal: 'operations',
-  treasurer: 'finance',
-  guide: 'support',
-  keeper: 'support',
-};
+import {
+  findAgentIdentity,
+  getAgentIdentity,
+  getRegisteredAgents,
+} from '../notifications/AgentRegistry.js';
 
 // ─── Supported Platforms ────────────────────────────────────────────────────
 
@@ -136,7 +97,7 @@ export function getChannelForDepartment(
  * Resolve an agent name to the correct channel ID for the given platform.
  *
  * Routing:
- *   1. Look up AGENT_DEPARTMENT[agent] → department
+ *   1. Look up agent's department from the registry
  *   2. Delegate to getChannelForDepartment(dept, platform)
  *   3. If that returns undefined, fall back to the `general` channel
  *
@@ -148,7 +109,7 @@ export function getChannelForAgent(
   agent: string,
   platform: ChannelPlatform,
 ): string | undefined {
-  const dept = (AGENT_DEPARTMENT[agent] as Department | undefined) ?? 'general';
+  const dept = (findAgentIdentity(agent)?.department ?? 'general') as Department;
   const direct = getChannelForDepartment(dept, platform);
   if (direct) return direct;
   // Fall back to general
@@ -163,13 +124,64 @@ export function getAlertsChannel(platform: ChannelPlatform): string | undefined 
 
 /** Get the emoji for an agent. Returns 🔔 for unknown agents. */
 export function getAgentEmoji(agent: string): string {
-  return AGENT_EMOJI[agent] || '\u{1F514}'; // 🔔
+  return getAgentIdentity(agent).emoji;
 }
 
 /** Get the department name for an agent. */
 export function getDepartmentForAgent(agent: string): string | undefined {
-  return AGENT_DEPARTMENT[agent];
+  return findAgentIdentity(agent)?.department;
 }
+
+// ─── Backward-Compatible Proxy Exports ──────────────────────────────────────
+// Existing code that imports AGENT_DEPARTMENT or AGENT_EMOJI as records
+// continues to work via Proxy. Full trap set so Object.keys() etc. work.
+// Strict lookup: unknown agents → undefined (old behavior).
+
+/** @deprecated Use getDepartmentForAgent() */
+export const AGENT_DEPARTMENT: Record<string, string> = new Proxy(
+  {} as Record<string, string>,
+  {
+    get: (_t, prop) => {
+      if (typeof prop === 'symbol') return undefined;
+      return findAgentIdentity(prop)?.department;
+    },
+    has: (_t, prop) => {
+      if (typeof prop === 'symbol') return false;
+      return !!findAgentIdentity(prop);
+    },
+    ownKeys: () => getRegisteredAgents(),
+    getOwnPropertyDescriptor: (_t, prop) => {
+      if (typeof prop === 'symbol') return undefined;
+      const ident = findAgentIdentity(prop as string);
+      return ident
+        ? { configurable: true, enumerable: true, value: ident.department }
+        : undefined;
+    },
+  },
+);
+
+/** @deprecated Use getAgentEmoji() */
+export const AGENT_EMOJI: Record<string, string> = new Proxy(
+  {} as Record<string, string>,
+  {
+    get: (_t, prop) => {
+      if (typeof prop === 'symbol') return undefined;
+      return findAgentIdentity(prop)?.emoji;
+    },
+    has: (_t, prop) => {
+      if (typeof prop === 'symbol') return false;
+      return !!findAgentIdentity(prop);
+    },
+    ownKeys: () => getRegisteredAgents(),
+    getOwnPropertyDescriptor: (_t, prop) => {
+      if (typeof prop === 'symbol') return undefined;
+      const ident = findAgentIdentity(prop as string);
+      return ident
+        ? { configurable: true, enumerable: true, value: ident.emoji }
+        : undefined;
+    },
+  },
+);
 
 // ─── Legacy Slack channel name map ──────────────────────────────────────────
 // Re-exported for backward compatibility with code that imports

--- a/packages/core/tests/channel-notifier.test.ts
+++ b/packages/core/tests/channel-notifier.test.ts
@@ -1,6 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { YClawEvent } from '../src/types/events.js';
 import type { IChannel } from '../src/interfaces/IChannel.js';
+import { initAgentRegistry } from '../src/notifications/AgentRegistry.js';
+import { createMockAgentConfigs } from './helpers/mock-agent-configs.js';
+
+beforeAll(() => { initAgentRegistry(createMockAgentConfigs()); });
 
 vi.mock('../src/logging/logger.js', () => ({
   createLogger: () => ({
@@ -59,7 +63,7 @@ function createMockChannel(
 
 function makeEvent(
   type: string,
-  source = 'builder',
+  source = 'architect',
   payload: Record<string, unknown> = {},
   correlationId = 'corr-abc',
 ): YClawEvent<unknown> {
@@ -144,7 +148,7 @@ describe('ChannelNotifier', () => {
     const channels = new Map<string, IChannel>([['slack', slack]]);
     const handler = await startAndGetHandler(channels);
 
-    await handler!(makeEvent('coord.task.completed', 'builder', {
+    await handler!(makeEvent('coord.task.completed', 'architect', {
       task_id: 't-1',
       description: 'done',
     }));
@@ -153,7 +157,7 @@ describe('ChannelNotifier', () => {
     expect(slack.send).toHaveBeenCalledTimes(1);
     const [target, message] = slack.send.mock.calls[0];
     expect(target.channelId).toBe('#yclaw-development');
-    expect(message.text).toContain('[Builder]');
+    expect(message.text).toContain('[Architect]');
     // Block Kit passthrough — opaque to the IChannel contract
     expect((message as any).blocks).toBeInstanceOf(Array);
   });
@@ -169,7 +173,7 @@ describe('ChannelNotifier', () => {
     ]);
     const handler = await startAndGetHandler(channels);
 
-    await handler!(makeEvent('coord.task.completed', 'builder', {
+    await handler!(makeEvent('coord.task.completed', 'architect', {
       task_id: 't-1',
       description: 'shipped',
     }));
@@ -185,7 +189,7 @@ describe('ChannelNotifier', () => {
     expect(discordTarget.channelId).toBe('1489421639274729502');
     // Discord uses plain markdown, never Block Kit
     expect((discordMsg as any).blocks).toBeUndefined();
-    expect(discordMsg.text).toContain('**Builder**');
+    expect(discordMsg.text).toContain('**Architect**');
   });
 
   it('skips Discord when no channel is configured for the department', async () => {
@@ -197,7 +201,7 @@ describe('ChannelNotifier', () => {
     ]);
     const handler = await startAndGetHandler(channels);
 
-    await handler!(makeEvent('coord.task.completed', 'builder'));
+    await handler!(makeEvent('coord.task.completed', 'architect'));
     await new Promise((r) => setTimeout(r, 30));
 
     expect(slack.send).toHaveBeenCalledTimes(1);
@@ -234,8 +238,8 @@ describe('ChannelNotifier', () => {
     ]);
     const handler = await startAndGetHandler(channels);
 
-    const first = makeEvent('coord.task.started', 'builder', { task_id: 't-1' }, 'proj-42');
-    const second = makeEvent('coord.task.completed', 'builder', { task_id: 't-1', description: 'done' }, 'proj-42');
+    const first = makeEvent('coord.task.started', 'architect', { task_id: 't-1' }, 'proj-42');
+    const second = makeEvent('coord.task.completed', 'architect', { task_id: 't-1', description: 'done' }, 'proj-42');
 
     await handler!(first);
     await new Promise((r) => setTimeout(r, 30));
@@ -268,7 +272,7 @@ describe('ChannelNotifier', () => {
     ]);
     const handler = await startAndGetHandler(channels);
 
-    await handler!(makeEvent('coord.task.blocked', 'builder', {
+    await handler!(makeEvent('coord.task.blocked', 'architect', {
       task_id: 't-1',
       message: 'Need API key',
     }));

--- a/packages/core/tests/channel-routing.test.ts
+++ b/packages/core/tests/channel-routing.test.ts
@@ -1,5 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import {
+  initAgentRegistry,
+  resetAgentRegistryForTests,
+  getAgentIdentity,
+  findAgentIdentity,
+  getRegisteredAgents,
+} from '../src/notifications/AgentRegistry.js';
+import {
+  AGENT_DEPARTMENT,
+  AGENT_EMOJI,
   getAgentEmoji,
   getAlertsChannel,
   getChannelForAgent,
@@ -7,6 +16,37 @@ import {
   getDepartmentForAgent,
   SLACK_CHANNELS,
 } from '../src/utils/channel-routing.js';
+import type { AgentConfig } from '../src/config/schema.js';
+
+// ─── Mock Agent Configs ─────────────────────────────────────────────────────
+
+function mockConfigs(): Map<string, AgentConfig> {
+  const configs = new Map<string, AgentConfig>();
+
+  const base = {
+    description: 'test',
+    model: { provider: 'anthropic' as const, model: 'claude-sonnet-4-20250514', maxTokens: 4096, temperature: 0.3 },
+    system_prompts: [],
+    triggers: [],
+    actions: [],
+    data_sources: [],
+    event_subscriptions: [],
+    event_publications: [],
+    review_bypass: [],
+  };
+
+  configs.set('strategist', { ...base, name: 'strategist', department: 'executive' });
+  configs.set('architect', { ...base, name: 'architect', department: 'development' });
+  configs.set('designer', { ...base, name: 'designer', department: 'development' });
+  configs.set('ember', { ...base, name: 'ember', department: 'marketing' });
+  configs.set('sentinel', { ...base, name: 'sentinel', department: 'operations' });
+  configs.set('treasurer', { ...base, name: 'treasurer', department: 'finance' });
+  configs.set('keeper', { ...base, name: 'keeper', department: 'support' });
+  configs.set('librarian', { ...base, name: 'librarian', department: 'operations' });
+  configs.set('mechanic', { ...base, name: 'mechanic', department: 'development' });
+
+  return configs;
+}
 
 // ─── Env helper ─────────────────────────────────────────────────────────────
 
@@ -49,6 +89,10 @@ const TRACKED_ENV_KEYS = [
 describe('channel-routing', () => {
   let envSnap: Record<string, string | undefined>;
 
+  beforeAll(() => {
+    initAgentRegistry(mockConfigs());
+  });
+
   beforeEach(() => {
     envSnap = snapshotEnv(TRACKED_ENV_KEYS);
     for (const k of TRACKED_ENV_KEYS) delete process.env[k];
@@ -58,10 +102,60 @@ describe('channel-routing', () => {
     restoreEnv(envSnap);
   });
 
-  describe('AGENT_EMOJI + getAgentEmoji', () => {
+  // ─── Council-mandated: Pre-init access throws ─────────────────────────
+
+  describe('pre-init guard', () => {
+    it('throws if accessed before initAgentRegistry()', () => {
+      resetAgentRegistryForTests();
+      expect(() => getAgentIdentity('strategist')).toThrow(
+        'AgentRegistry accessed before initAgentRegistry()',
+      );
+      // Re-init for remaining tests
+      initAgentRegistry(mockConfigs());
+    });
+  });
+
+  // ─── Council-mandated: Proxy enumeration works ────────────────────────
+
+  describe('proxy enumeration', () => {
+    it('Object.keys(AGENT_DEPARTMENT) returns all registered agent names', () => {
+      const keys = Object.keys(AGENT_DEPARTMENT);
+      expect(keys).toContain('strategist');
+      expect(keys).toContain('architect');
+      expect(keys).toContain('librarian');
+      expect(keys).toContain('mechanic');
+      expect(keys.length).toBe(mockConfigs().size);
+    });
+
+    it('Object.keys(AGENT_EMOJI) returns all registered agent names', () => {
+      const keys = Object.keys(AGENT_EMOJI);
+      expect(keys).toContain('strategist');
+      expect(keys).toContain('librarian');
+    });
+
+    it('Object.entries(AGENT_DEPARTMENT) works', () => {
+      const entries = Object.entries(AGENT_DEPARTMENT);
+      const strategistEntry = entries.find(([k]) => k === 'strategist');
+      expect(strategistEntry).toEqual(['strategist', 'executive']);
+    });
+  });
+
+  // ─── Council-mandated: Proxy unknown key returns undefined ────────────
+
+  describe('proxy unknown key', () => {
+    it('AGENT_DEPARTMENT["fake_agent"] returns undefined', () => {
+      expect(AGENT_DEPARTMENT['fake_agent']).toBeUndefined();
+    });
+
+    it('AGENT_EMOJI["fake_agent"] returns undefined', () => {
+      expect(AGENT_EMOJI['fake_agent']).toBeUndefined();
+    });
+  });
+
+  describe('getAgentEmoji', () => {
     it('returns the expected emoji for known agents', () => {
-      expect(getAgentEmoji('builder')).toBe('\u{1F6E0}\uFE0F');
       expect(getAgentEmoji('strategist')).toBe('\u{1F9E0}');
+      expect(getAgentEmoji('architect')).toBe('\u{1F3D7}\uFE0F');
     });
 
     it('falls back to bell for unknown agents', () => {
@@ -71,8 +165,13 @@ describe('channel-routing', () => {
 
   describe('getDepartmentForAgent', () => {
     it('maps development agents correctly', () => {
-      expect(getDepartmentForAgent('builder')).toBe('development');
       expect(getDepartmentForAgent('architect')).toBe('development');
+      expect(getDepartmentForAgent('mechanic')).toBe('development');
+    });
+
+    // Council-mandated: YAML-only agents route correctly
+    it('maps librarian to operations (YAML-derived, no hardcoded map)', () => {
+      expect(getDepartmentForAgent('librarian')).toBe('operations');
     });
 
     it('returns undefined for unknown agents', () => {
@@ -82,11 +181,21 @@ describe('channel-routing', () => {
 
   describe('Slack routing (default channel names)', () => {
     it('falls back to #yclaw-<dept> when no SLACK_CHANNEL_* env is set', () => {
-      expect(getChannelForAgent('builder', 'slack')).toBe('#yclaw-development');
+      expect(getChannelForAgent('architect', 'slack')).toBe('#yclaw-development');
       expect(getChannelForAgent('strategist', 'slack')).toBe('#yclaw-executive');
       expect(getChannelForAgent('treasurer', 'slack')).toBe('#yclaw-finance');
     });
 
+    // Council-mandated: YAML-only agents route correctly
+    it('routes librarian to #yclaw-operations via YAML config', () => {
+      expect(getChannelForAgent('librarian', 'slack')).toBe('#yclaw-operations');
+    });
+
+    it('routes mechanic to #yclaw-development via YAML config', () => {
+      expect(getChannelForAgent('mechanic', 'slack')).toBe('#yclaw-development');
+    });
+
+    // Council-mandated: Unknown agent falls back to general
     it('routes unknown agents to #yclaw-general', () => {
       expect(getChannelForAgent('mystery-agent', 'slack')).toBe('#yclaw-general');
     });
@@ -99,19 +208,19 @@ describe('channel-routing', () => {
 
     it('honours SLACK_CHANNEL_* env overrides when set', () => {
       process.env.SLACK_CHANNEL_DEVELOPMENT = 'C1234567890';
-      expect(getChannelForAgent('builder', 'slack')).toBe('C1234567890');
+      expect(getChannelForAgent('architect', 'slack')).toBe('C1234567890');
       expect(getChannelForDepartment('development', 'slack')).toBe('C1234567890');
     });
 
     it('ignores empty-string overrides and keeps the default', () => {
       process.env.SLACK_CHANNEL_DEVELOPMENT = '   ';
-      expect(getChannelForAgent('builder', 'slack')).toBe('#yclaw-development');
+      expect(getChannelForAgent('architect', 'slack')).toBe('#yclaw-development');
     });
   });
 
   describe('Discord routing (no default channels)', () => {
     it('returns undefined when nothing is configured', () => {
-      expect(getChannelForAgent('builder', 'discord')).toBeUndefined();
+      expect(getChannelForAgent('architect', 'discord')).toBeUndefined();
       expect(getAlertsChannel('discord')).toBeUndefined();
     });
 
@@ -122,14 +231,77 @@ describe('channel-routing', () => {
       expect(getChannelForAgent('unknown-agent', 'discord')).toBe('1489421589941325904');
     });
 
+    // Council-mandated: YAML-only agents route correctly via Discord
+    it('routes librarian to operations channel via Discord', () => {
+      process.env.DISCORD_CHANNEL_OPERATIONS = '1489421700000000000';
+      expect(getChannelForAgent('librarian', 'discord')).toBe('1489421700000000000');
+    });
+
     it('falls back from a department to GENERAL when the department env is unset', () => {
       process.env.DISCORD_CHANNEL_GENERAL = '1489421589941325904';
-      expect(getChannelForAgent('builder', 'discord')).toBe('1489421589941325904');
+      expect(getChannelForAgent('architect', 'discord')).toBe('1489421589941325904');
     });
 
     it('resolves the alerts channel independently', () => {
       process.env.DISCORD_CHANNEL_ALERTS = '1489421718945661049';
       expect(getAlertsChannel('discord')).toBe('1489421718945661049');
     });
+  });
+
+  // ─── Council-mandated: Agent in YAML but not in display overrides ─────
+
+  describe('agents without display overrides', () => {
+    it('gets fallback emoji (bell) + correct department routing', () => {
+      // Add a synthetic agent with no display override
+      const configs = mockConfigs();
+      configs.set('new_agent', {
+        name: 'new_agent',
+        department: 'finance',
+        description: 'test',
+        model: { provider: 'anthropic' as const, model: 'claude-sonnet-4-20250514', maxTokens: 4096, temperature: 0.3 },
+        system_prompts: [],
+        triggers: [],
+        actions: [],
+        data_sources: [],
+        event_subscriptions: [],
+        event_publications: [],
+        review_bypass: [],
+      });
+      initAgentRegistry(configs);
+
+      expect(getAgentEmoji('new_agent')).toBe('\u{1F514}'); // 🔔 fallback
+      expect(getDepartmentForAgent('new_agent')).toBe('finance');
+      expect(getChannelForAgent('new_agent', 'slack')).toBe('#yclaw-finance');
+
+      // Re-init with standard configs for remaining tests
+      initAgentRegistry(mockConfigs());
+    });
+  });
+});
+
+// ─── AgentRegistry unit tests ───────────────────────────────────────────────
+
+describe('AgentRegistry', () => {
+  beforeAll(() => {
+    initAgentRegistry(mockConfigs());
+  });
+
+  it('findAgentIdentity returns undefined for unknown agents', () => {
+    expect(findAgentIdentity('nonexistent')).toBeUndefined();
+  });
+
+  it('getAgentIdentity returns fallback for unknown agents', () => {
+    const ident = getAgentIdentity('nonexistent');
+    expect(ident.id).toBe('nonexistent');
+    expect(ident.department).toBe('general');
+    expect(ident.emoji).toBe('\u{1F514}');
+  });
+
+  it('getRegisteredAgents returns all agent IDs', () => {
+    const agents = getRegisteredAgents();
+    expect(agents).toContain('strategist');
+    expect(agents).toContain('librarian');
+    expect(agents).toContain('mechanic');
+    expect(agents.length).toBe(mockConfigs().size);
   });
 });

--- a/packages/core/tests/discord-executor.test.ts
+++ b/packages/core/tests/discord-executor.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DiscordChannelAdapter } from '../src/adapters/channels/DiscordChannelAdapter.js';
+import { initAgentRegistry } from '../src/notifications/AgentRegistry.js';
+import { createMockAgentConfigs } from './helpers/mock-agent-configs.js';
+
+beforeAll(() => { initAgentRegistry(createMockAgentConfigs()); });
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 

--- a/packages/core/tests/helpers/mock-agent-configs.ts
+++ b/packages/core/tests/helpers/mock-agent-configs.ts
@@ -1,0 +1,50 @@
+import type { AgentConfig } from '../../src/config/schema.js';
+
+/**
+ * Create a minimal set of mock AgentConfig objects for tests that
+ * depend on the AgentRegistry being initialized.
+ */
+export function createMockAgentConfigs(): Map<string, AgentConfig> {
+  const configs = new Map<string, AgentConfig>();
+
+  const base = {
+    description: 'test agent',
+    model: {
+      provider: 'anthropic' as const,
+      model: 'claude-sonnet-4-20250514',
+      maxTokens: 4096,
+      temperature: 0.3,
+    },
+    system_prompts: [],
+    triggers: [],
+    actions: [],
+    data_sources: [],
+    event_subscriptions: [],
+    event_publications: [],
+    review_bypass: [],
+  };
+
+  // All 13 production agents + librarian and mechanic
+  const agents: Array<[string, string]> = [
+    ['strategist', 'executive'],
+    ['reviewer', 'executive'],
+    ['architect', 'development'],
+    ['designer', 'development'],
+    ['mechanic', 'development'],
+    ['ember', 'marketing'],
+    ['forge', 'marketing'],
+    ['scout', 'marketing'],
+    ['sentinel', 'operations'],
+    ['librarian', 'operations'],
+    ['treasurer', 'finance'],
+    ['guide', 'support'],
+    ['keeper', 'support'],
+    ['signal', 'operations'],
+  ];
+
+  for (const [name, department] of agents) {
+    configs.set(name, { ...base, name, department: department as AgentConfig['department'] });
+  }
+
+  return configs;
+}

--- a/packages/core/tests/journaler.test.ts
+++ b/packages/core/tests/journaler.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import type { YClawEvent } from '../src/types/events.js';
+import { initAgentRegistry } from '../src/notifications/AgentRegistry.js';
+import { createMockAgentConfigs } from './helpers/mock-agent-configs.js';
+
+beforeAll(() => { initAgentRegistry(createMockAgentConfigs()); });
 
 // ─── Mock Logger ────────────────────────────────────────────────────────────
 

--- a/packages/core/tests/slack-notifier.test.ts
+++ b/packages/core/tests/slack-notifier.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import type { YClawEvent } from '../src/types/events.js';
+import { initAgentRegistry } from '../src/notifications/AgentRegistry.js';
+import { createMockAgentConfigs } from './helpers/mock-agent-configs.js';
+
+beforeAll(() => { initAgentRegistry(createMockAgentConfigs()); });
 
 // ─── Mock Logger ────────────────────────────────────────────────────────────
 
@@ -55,7 +59,7 @@ function createMockSlack() {
 
 function makeEvent(
   type: string,
-  source = 'builder',
+  source = 'architect',
   payload: Record<string, unknown> = {},
   correlationId = 'corr-123',
 ): YClawEvent<unknown> {
@@ -77,11 +81,10 @@ function makeEvent(
 describe('slack-blocks', () => {
   describe('getAgentEmoji', () => {
     it('returns correct emoji for known agents', () => {
-      expect(getAgentEmoji('builder')).toBe('\u{1F6E0}\uFE0F');    // 🛠️
       expect(getAgentEmoji('strategist')).toBe('\u{1F9E0}');         // 🧠
-      expect(getAgentEmoji('architect')).toBe('\u{1F4D0}');          // 📐
-      expect(getAgentEmoji('deployer')).toBe('\u{1F680}');           // 🚀
-      expect(getAgentEmoji('signal')).toBe('\u{1F4E1}');             // 📡
+      expect(getAgentEmoji('architect')).toBe('\u{1F3D7}\uFE0F');   // 🏗️
+      expect(getAgentEmoji('sentinel')).toBe('\u{1F510}');           // 🔐
+      expect(getAgentEmoji('signal')).toBe('\u{1F4CA}');             // 📊
     });
 
     it('returns bell emoji for unknown agents', () => {
@@ -91,10 +94,9 @@ describe('slack-blocks', () => {
 
   describe('getChannelForAgent', () => {
     it('routes development agents to #yclaw-development', () => {
-      expect(getChannelForAgent('builder')).toBe('#yclaw-development');
       expect(getChannelForAgent('architect')).toBe('#yclaw-development');
-      expect(getChannelForAgent('deployer')).toBe('#yclaw-development');
       expect(getChannelForAgent('designer')).toBe('#yclaw-development');
+      expect(getChannelForAgent('mechanic')).toBe('#yclaw-development');
     });
 
     it('routes executive agents to #yclaw-executive', () => {
@@ -129,7 +131,7 @@ describe('slack-blocks', () => {
 
   describe('buildCoordBlock', () => {
     it('builds section block with agent emoji and action', () => {
-      const event = makeEvent('coord.task.completed', 'builder', {
+      const event = makeEvent('coord.task.completed', 'architect', {
         task_id: 't-1', description: 'Implemented feature X',
       });
       const blocks = buildCoordBlock(event);
@@ -137,13 +139,13 @@ describe('slack-blocks', () => {
       expect(blocks.length).toBeGreaterThanOrEqual(1);
       expect(blocks[0]!.type).toBe('section');
       const text = blocks[0]!.text!.text;
-      expect(text).toContain('[Builder]');
+      expect(text).toContain('[Architect]');
       expect(text).toContain('completed task');
       expect(text).toContain('Implemented feature X');
     });
 
     it('includes artifact link when present', () => {
-      const event = makeEvent('coord.deliverable.submitted', 'builder', {
+      const event = makeEvent('coord.deliverable.submitted', 'architect', {
         task_id: 't-1',
         artifact_url: 'https://github.com/yclaw-ai/yclaw/pull/42',
         artifact_type: 'pr',
@@ -154,7 +156,7 @@ describe('slack-blocks', () => {
     });
 
     it('includes context block with correlation and task IDs', () => {
-      const event = makeEvent('coord.task.completed', 'builder', {
+      const event = makeEvent('coord.task.completed', 'architect', {
         task_id: 't-1',
       }, 'proj-1');
       const blocks = buildCoordBlock(event);
@@ -167,14 +169,14 @@ describe('slack-blocks', () => {
     it('includes target agent when specified', () => {
       const event = { ...makeEvent('coord.task.requested', 'strategist', {
         task_id: 't-1', description: 'Build something',
-      }), target: 'builder' };
+      }), target: 'architect' };
       const blocks = buildCoordBlock(event);
       const text = blocks[0]!.text!.text;
-      expect(text).toContain('[Builder]');
+      expect(text).toContain('[Architect]');
     });
 
     it('shows blocked needs for blocked events', () => {
-      const event = makeEvent('coord.task.blocked', 'builder', {
+      const event = makeEvent('coord.task.blocked', 'architect', {
         task_id: 't-1', message: 'Need API credentials',
       });
       const blocks = buildCoordBlock(event);
@@ -253,7 +255,7 @@ describe('SlackNotifier', () => {
 
   it('posts Block Kit message to correct department channel', async () => {
     await startAndGetHandler();
-    const event = makeEvent('coord.task.completed', 'builder', {
+    const event = makeEvent('coord.task.completed', 'architect', {
       task_id: 't-1', description: 'done',
     });
 
@@ -262,7 +264,7 @@ describe('SlackNotifier', () => {
     await new Promise(r => setTimeout(r, 50));
 
     expect(slack.execute).toHaveBeenCalledWith('message', expect.objectContaining({
-      channel: '#yclaw-development', // builder's department
+      channel: '#yclaw-development', // architect's department
       blocks: expect.any(Array),
     }));
   });
@@ -276,7 +278,7 @@ describe('SlackNotifier', () => {
 
   it('saves thread_ts from first message for correlation_id', async () => {
     await startAndGetHandler();
-    const event = makeEvent('coord.task.completed', 'builder', {
+    const event = makeEvent('coord.task.completed', 'architect', {
       task_id: 't-1',
     }, 'proj-1');
 
@@ -297,7 +299,7 @@ describe('SlackNotifier', () => {
     // Seed the thread_ts in Redis
     redis._store.set('slack:thread:proj-1', '1111111111.111111');
 
-    const event = makeEvent('coord.deliverable.submitted', 'builder', {
+    const event = makeEvent('coord.deliverable.submitted', 'architect', {
       task_id: 't-1', artifact_type: 'pr',
       artifact_url: 'https://github.com/example/pr/1',
     }, 'proj-1');
@@ -313,7 +315,7 @@ describe('SlackNotifier', () => {
 
   it('posts escalation events to both department channel and #yclaw-alerts', async () => {
     await startAndGetHandler();
-    const event = makeEvent('coord.task.blocked', 'builder', {
+    const event = makeEvent('coord.task.blocked', 'architect', {
       task_id: 't-1', message: 'Need API key',
     });
 
@@ -356,7 +358,7 @@ describe('SlackNotifier', () => {
         data: { ts: '2222222222.222222', channel: '#yclaw-development' },
       });
 
-    const event = makeEvent('coord.task.completed', 'builder', {
+    const event = makeEvent('coord.task.completed', 'architect', {
       task_id: 't-1',
     }, 'proj-1');
 
@@ -372,7 +374,7 @@ describe('SlackNotifier', () => {
     await startAndGetHandler();
     slack.execute.mockRejectedValueOnce(new Error('Slack API down'));
 
-    const event = makeEvent('coord.task.completed', 'builder', {
+    const event = makeEvent('coord.task.completed', 'architect', {
       task_id: 't-1',
     });
 


### PR DESCRIPTION
## Summary

- **Single source of truth**: Agent identity/routing now derived from YAML configs at bootstrap via `initAgentRegistry()`, not 4 duplicate hardcoded maps
- **New agents Just Work**: Add a YAML to `departments/` and routing, emoji, Discord identity all work automatically
- **Fixes librarian + mechanic**: Both were missing from all 4 maps — now route correctly via their YAML `department` field
- **Removes stale entries**: `builder` and `deployer` no longer pollute the registry

## Architecture

```
departments/*.yaml → loadAllAgentConfigs() → AgentRouter
                                               ↓
                                        initAgentRegistry()
                                               ↓
                                         AgentRegistry (Map)
                                        /        |          \
                          channel-routing    AgentRegistry    slack.ts
                          (Proxy shims)    (getAgentIdentity)  (Proxy shim)
```

## Files changed

| File | Change |
|------|--------|
| `src/notifications/AgentRegistry.ts` | Dynamic registry + `initAgentRegistry()` + display overrides + Proxy backward-compat |
| `src/utils/channel-routing.ts` | Delete hardcoded `AGENT_DEPARTMENT`/`AGENT_EMOJI` maps, derive from registry |
| `src/modules/journaler.ts` | Delete local `AGENT_EMOJI` duplicate, use shared `getAgentEmoji()` |
| `src/actions/slack.ts` | Replace hardcoded `AGENT_IDENTITIES` with registry Proxy |
| `src/bootstrap/agents.ts` | Call `initAgentRegistry()` after `AgentRouter` init |
| `tests/helpers/mock-agent-configs.ts` | **NEW** — shared mock configs for test setup |
| `tests/channel-routing.test.ts` | Full rewrite with council-mandated test cases |
| `tests/discord-executor.test.ts` | Add registry init to setup |
| `tests/journaler.test.ts` | Add registry init to setup |
| `tests/channel-notifier.test.ts` | Add registry init, replace stale agent refs |
| `tests/slack-notifier.test.ts` | Add registry init, replace stale agent refs |

## Council-mandated test coverage

- [x] Pre-init access throws — `getAgentIdentity('strategist')` before `initAgentRegistry()` → Error
- [x] Proxy enumeration works — `Object.keys(AGENT_DEPARTMENT)` returns all registered agents
- [x] Proxy unknown key returns undefined — `AGENT_DEPARTMENT['fake_agent']` → undefined
- [x] YAML-only agents route correctly — `getChannelForAgent('librarian', 'discord')` → operations channel
- [x] Unknown agent falls back to general — `getChannelForAgent('nonexistent', 'slack')` → `#yclaw-general`
- [x] Journaler uses shared emoji — no local `AGENT_EMOJI` map in `journaler.ts`
- [x] Snowflake routing preserved — discord-executor test still mocks channel-routing, resolveChannelId ordering untouched

## Backward compatibility

All deprecated maps (`AGENT_DEPARTMENT`, `AGENT_EMOJI`, `AGENT_REGISTRY`, `AGENT_IDENTITIES`) are preserved as Proxy exports with full trap sets (`get` + `has` + `ownKeys` + `getOwnPropertyDescriptor`). Existing consumers work unchanged.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (111 files, 1812 tests)
- [x] No `AGENT_DEPARTMENT[` or `AGENT_EMOJI[` bracket access in `src/`
- [x] `resolveChannelId()` ordering unchanged (PR #77 fix preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)