### PR TITLE
fix: disable Elvis pre-check for Architect reconciler crons

### DIFF
--- a/departments/development/architect.yaml
+++ b/departments/development/architect.yaml
@@ -173,5 +173,5 @@ review_bypass: []
 
 heartbeat:
   precheck:
-    enabled: true
+    enabled: false
     maxSilenceHours: 6

--- a/packages/core/src/bootstrap/agents.ts
+++ b/packages/core/src/bootstrap/agents.ts
@@ -404,12 +404,15 @@ export async function initAgents(
     if (!config) continue;
 
     // Elvis pre-check: skip the LLM if the agent has no pending work.
-    // Controlled per-agent via YAML heartbeat.precheck.enabled (default: true).
+    // Controlled per-agent via YAML heartbeat.precheck.enabled (default: true),
+    // and overridable per-trigger via trigger.precheck.enabled.
     // Strategist is hard-excluded: it creates work from GitHub issues that haven't
     // been triaged into Redis yet, so queue-depth checks would produce a
     // chicken-and-egg false negative (see issue #447 post-mortem).
+    // Architect is disabled at agent level: stale_issue_sweep and pipeline_health_scan
+    // are reconciler/discovery tasks that find work not yet in internal queues.
     const precheckCfg = config.heartbeat?.precheck;
-    const precheckEnabled = agent !== 'strategist' && precheckCfg?.enabled !== false;
+    const agentPrecheckEnabled = agent !== 'strategist' && precheckCfg?.enabled !== false;
     const precheckMaxSilenceMs = ((precheckCfg?.maxSilenceHours ?? 6) * 3_600_000);
 
     cronManager.schedule(agent, schedule, task, async () => {
@@ -425,6 +428,14 @@ export async function initAgents(
       }
 
       // Elvis pre-check gate — deterministic, zero-LLM
+      // Per-trigger override: trigger.precheck.enabled can override agent-level setting.
+      // Reconciler crons (stale_issue_sweep, pipeline_health_scan) should set this to false.
+      const triggerCfg = config.triggers?.find(
+        t => t.type === 'cron' && t.task === task,
+      );
+      const precheckEnabled = (triggerCfg && 'precheck' in triggerCfg
+        ? triggerCfg.precheck?.enabled
+        : undefined) ?? agentPrecheckEnabled;
       if (precheckEnabled && deployRedis) {
         const precheck = await shouldRunHeartbeat(
           agent,

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -18,7 +18,10 @@ export const CronTriggerSchema = z.object({
   type: z.literal('cron'),
   schedule: z.string(),
   task: z.string(),
+  description: z.string().optional(),
   prompts: z.array(z.string()).optional(),
+  /** Per-trigger pre-check override. Reconciler crons should set enabled: false. */
+  precheck: z.object({ enabled: z.boolean() }).optional(),
 });
 
 export const EventTriggerSchema = z.object({


### PR DESCRIPTION
## Summary

- **Disable Elvis pre-check for Architect** — `heartbeat.precheck.enabled: false` in `architect.yaml`. Reconciler crons (`stale_issue_sweep`, `pipeline_health_scan`) discover work on GitHub that isn't in Redis yet. Pre-check kills them with "no pending work" — classic chicken-and-egg (same bug as Strategist, see #447).
- **Add per-trigger `precheck.enabled` override** — new optional field in `CronTriggerSchema`. Future configs can selectively bypass pre-check on reconciler crons while keeping it on for regular heartbeats.
- **Strategist `reconcile_pipeline` already removed** in PR #85 — no changes needed here.

## Root cause

```
14:30:00 [architect] Cron triggered: stale_issue_sweep
14:30:00 [bootstrap:agents] [architect] Elvis pre-check: skipping stale_issue_sweep — no pending work
```

Elvis pre-check checks Redis queues and event streams for "pending work." But `stale_issue_sweep` exists to find work on GitHub that *isn't in Redis yet*. Empty internal queues does not mean no work.

## Files changed

| File | Change |
|------|--------|
| `departments/development/architect.yaml` | `precheck.enabled: true` → `false` |
| `packages/core/src/config/schema.ts` | Add optional `precheck` + `description` to `CronTriggerSchema` |
| `packages/core/src/bootstrap/agents.ts` | Per-trigger precheck override: `trigger.precheck.enabled` overrides agent-level setting |

## Per-trigger bypass (future use)

Agents can now keep pre-check enabled at the agent level while exempting specific crons:

```yaml
triggers:
  - type: cron
    schedule: "*/30 * * * *"
    task: stale_issue_sweep
    precheck:
      enabled: false  # Reconciler — always run
```

## Verification (post-deploy)

```
# GOOD: "[architect] Starting execution: stale_issue_sweep (trigger: cron)"
# BAD:  "[architect] Elvis pre-check: skipping stale_issue_sweep — no pending work"
```

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (111 files, 1812 tests)
- [x] YAML valid
- [x] `reconcile_pipeline` already removed (PR #85)

🤖 Generated with [Claude Code](https://claude.com/claude-code)