### PR TITLE
fix: fail-open orphan sweeper + isSessionActive to stop AO session death

### DIFF
--- a/ao/ao-bridge-server.mjs
+++ b/ao/ao-bridge-server.mjs
@@ -1619,17 +1619,20 @@ async function sweepOrphanedSessionHarvests() {
   }
 
   for (const state of states) {
+    const orphanMissCount = state._orphanMissCount || 0;
     if (!sessionList.includes(state.sessionId)) {
       // Require consecutive confirmed misses before harvesting
-      state._orphanMissCount = (state._orphanMissCount || 0) + 1;
+      state._orphanMissCount = orphanMissCount + 1;
+      writeSessionMonitorState(state);
       if (state._orphanMissCount >= 2) {
         console.log(`[ao-bridge] Orphan confirmed after ${state._orphanMissCount} consecutive misses: ${state.sessionId}`);
         void runTrackedHarvest(state, 'orphan-sweeper');
       } else {
         console.warn(`[ao-bridge] Sweeper miss ${state._orphanMissCount}/2 for ${state.sessionId}; deferring harvest`);
       }
-    } else {
+    } else if (orphanMissCount !== 0) {
       state._orphanMissCount = 0; // Reset on successful sighting
+      writeSessionMonitorState(state);
     }
   }
 }

--- a/ao/ao-bridge-server.mjs
+++ b/ao/ao-bridge-server.mjs
@@ -842,8 +842,11 @@ async function isSessionActive(sessionId) {
   try {
     const result = await runAo(['session', 'ls'], '/app', 10000);
     return result.stdout.includes(sessionId);
-  } catch {
-    return false;
+  } catch (err) {
+    // Cannot determine session state — assume alive.
+    // The monitor deadline will catch truly dead sessions via timeout.
+    console.warn(`[ao-bridge] isSessionActive check failed for ${sessionId}, assuming alive:`, err?.message || String(err));
+    return true;
   }
 }
 
@@ -1611,12 +1614,22 @@ async function sweepOrphanedSessionHarvests() {
     const result = await runAo(['session', 'ls'], '/app', 10000);
     sessionList = result.stdout;
   } catch (err) {
-    console.warn('[ao-bridge] Session harvest sweeper could not list sessions:', err?.message || String(err));
+    console.warn('[ao-bridge] Session harvest sweeper could not list sessions (fail-open, skipping sweep):', err?.message || String(err));
+    return; // No data = no action. Never kill sessions when we can't see the ground truth.
   }
 
   for (const state of states) {
     if (!sessionList.includes(state.sessionId)) {
-      void runTrackedHarvest(state, 'orphan-sweeper');
+      // Require consecutive confirmed misses before harvesting
+      state._orphanMissCount = (state._orphanMissCount || 0) + 1;
+      if (state._orphanMissCount >= 2) {
+        console.log(`[ao-bridge] Orphan confirmed after ${state._orphanMissCount} consecutive misses: ${state.sessionId}`);
+        void runTrackedHarvest(state, 'orphan-sweeper');
+      } else {
+        console.warn(`[ao-bridge] Sweeper miss ${state._orphanMissCount}/2 for ${state.sessionId}; deferring harvest`);
+      }
+    } else {
+      state._orphanMissCount = 0; // Reset on successful sighting
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Orphan sweeper fail-open**: When `ao session ls` fails (OOM/timeout), the sweeper now returns early instead of falling through with `sessionList = ''` — which matched zero session IDs and killed every active session
- **isSessionActive fail-open**: Returns `true` on check failure instead of `false`. "Can't check" ≠ "session is dead". The monitor deadline catches truly dead sessions via timeout
- **Consecutive miss threshold**: Requires 2 confirmed absences before declaring orphan, eliminating race condition false positives from stale listings

**Root cause chain:** 512MB RAM → gh/ao CLI OOM → `ao session ls` fails → fail-closed bugs → ALL sessions killed as "orphans" within 60-90s of spawn. Every spawn today (#81, #75, #76, #74) was killed by the sweeper. All harvests show `dirty=false` — Claude Code never wrote a single line.

**Also applied (infra, not in this PR):** Registered task definition `:20` with `yclaw-ecs-task-execution-role` (the one that can actually pull ECR images and read Secrets Manager), replacing the broken `yclaw-task-execution-production` role on `:19`.

## Test plan

- [ ] Deploy code fix to AO container
- [ ] Update ECS service to use task def `:20`
- [ ] Watch logs for next `stale_issue_sweep` cycle (every 30 min)
- [ ] Verify sessions survive >60s (should run 5-30+ minutes)
- [ ] Verify `dirty=true` in harvest logs (Claude Code actually did work)
- [ ] Check for `Sweeper miss 1/2` logs (consecutive miss working)
- [ ] Check for `assuming alive` logs (fail-open isSessionActive working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)