### PR TITLE
fix: P0 org-audit — event policy, Gaze scrub, cron throttle, Ember unfreeze, mechanic upgrade

### DIFF
--- a/departments/development/architect.yaml
+++ b/departments/development/architect.yaml
@@ -47,7 +47,7 @@ triggers:
   # Stale issue sweep — catches issues missed by real-time event triggers
   # Removes stale in-progress labels, delegates eligible unworked issues to AO
   - type: cron
-    schedule: "*/30 * * * *"
+    schedule: "0 */6 * * *"
     task: stale_issue_sweep
     model:
       provider: anthropic

--- a/departments/development/mechanic.yaml
+++ b/departments/development/mechanic.yaml
@@ -7,9 +7,9 @@ description: >-
 
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
   temperature: 0.1
-  maxTokens: 4096
+  maxTokens: 8192
 
 system_prompts:
   - mission_statement.md

--- a/departments/marketing/ember.yaml
+++ b/departments/marketing/ember.yaml
@@ -27,16 +27,16 @@ triggers:
     schedule: "10 13 * * *"
     task: daily_standup
   - type: cron
-    schedule: "0 0 31 12 *"        # DISABLED — re-enable when review + publish pipeline works
+    schedule: "0 14 * * 1-5"       # Weekdays 14:00 UTC
     task: daily_content_batch
   - type: cron
-    schedule: "0 0 31 12 *"        # DISABLED
+    schedule: "30 16 * * 1-5"      # Weekdays 16:30 UTC
     task: midday_post
   - type: cron
-    schedule: "0 0 31 12 *"        # DISABLED
+    schedule: "0 22 * * 1-5"       # Weekdays 22:00 UTC
     task: afternoon_engagement
   - type: cron
-    schedule: "0 0 31 12 *"        # DISABLED
+    schedule: "0 15 * * 6,0"       # Weekends 15:00 UTC
     task: weekend_content
   - type: event
     event: forge:asset_ready

--- a/departments/operations/sentinel.yaml
+++ b/departments/operations/sentinel.yaml
@@ -40,7 +40,7 @@ triggers:
     event: strategist:sentinel_directive
     task: handle_directive
   - type: cron
-    schedule: "*/5 * * * *"
+    schedule: "*/30 * * * *"
     task: ao_health_check
   - type: event
     event: claudeception:reflect

--- a/prompts/protocol-overview.md
+++ b/prompts/protocol-overview.md
@@ -8,7 +8,7 @@
 
 YClaw is an open-source AI agent orchestration harness. It provides the infrastructure to run an organization of AI agents — with real department structures, event-driven coordination, HMAC-signed event buses, persistent agent memory, and human oversight through approval gates.
 
-YClaw was extracted from a production system (Gaze Protocol) that ran 12 autonomous agents for over a year. The codebase has been scrubbed of all Gaze-specific content and released under AGPL-3.0.
+YClaw is built on production-tested infrastructure that ran 12 autonomous agents for over a year before being open-sourced. The codebase is released under AGPL-3.0.
 
 ## How It Works
 

--- a/yclaw-event-policy.yaml
+++ b/yclaw-event-policy.yaml
@@ -11,14 +11,28 @@ schemaVersion: "1.0"
 
 sources:
   # Executive ────────────────────────────────────────────────────────────
-  # Strategist — strategic directives (wildcard across strategist:* events)
+  # Strategist — strategic directives
   agent:strategist:
     allowedEventTypes:
-      - "strategist:*"
+      - "strategist:weekly_directive"
+      - "strategist:midweek_adjustment"
+      - "strategist:architect_directive"
+      - "strategist:designer_directive"
+      - "strategist:design_generate"
+      - "strategist:standup_synthesis"
+      - "strategist:sentinel_directive"
+      - "strategist:keeper_directive"
+      - "strategist:ember_directive"
+      - "strategist:forge_directive"
+      - "strategist:scout_directive"
+      - "strategist:treasurer_directive"
+      - "strategist:guide_directive"
+      - "strategist:reviewer_directive"
 
   # Reviewer — review verdicts
   agent:reviewer:
     allowedEventTypes:
+      - "standup:report"
       - "reviewer:flagged"
       - "reviewer:approved"
       - "reviewer:rejected"
@@ -27,82 +41,90 @@ sources:
   # Architect — build directives, deploy governance, and AO coordination
   agent:architect:
     allowedEventTypes:
+      - "standup:report"
       - "architect:build_directive"
-      - "architect:repair_directive"
       - "architect:pr_review"
-      - "architect:deploy_review"
       - "architect:design_directive"
       - "architect:mechanic_task"
       - "architect:task_complete"
       - "architect:task_blocked"
+      - "architect:deploy_review"
       - "deploy:assess"
       - "deploy:approve"
 
   # Designer — design events
   agent:designer:
     allowedEventTypes:
-      - "designer:review_complete"
-      - "designer:design_update"
-      - "designer:mockup_ready"
+      - "standup:report"
+      - "designer:design_review"
+      - "designer:design_generated"
 
   # Mechanic — maintenance events
   agent:mechanic:
     allowedEventTypes:
-      - "mechanic:task_complete"
-      - "mechanic:lockfile_updated"
+      - "mechanic:task_completed"
+      - "mechanic:task_failed"
 
   # Marketing ────────────────────────────────────────────────────────────
   # Ember — content events only
   agent:ember:
     allowedEventTypes:
-      - "content:draft"
-      - "content:published"
+      - "standup:report"
+      - "ember:needs_asset"
+      - "ember:content_ready"
+      - "review:pending"
 
   # Forge — asset creation events
   agent:forge:
     allowedEventTypes:
+      - "standup:report"
       - "forge:asset_ready"
-      - "forge:asset_failed"
 
   # Scout — research and outreach events
   agent:scout:
     allowedEventTypes:
+      - "standup:report"
       - "scout:intel_report"
       - "scout:outreach_ready"
-      - "scout:competitor_alert"
+      - "scout:pipeline_report"
+      - "review:pending"
 
   # Operations ───────────────────────────────────────────────────────────
   # Sentinel — operational events
   agent:sentinel:
     allowedEventTypes:
+      - "standup:report"
       - "sentinel:alert"
-      - "sentinel:health"
+      - "sentinel:status_report"
+      - "sentinel:quality_report"
 
   # Librarian — knowledge management events
   agent:librarian:
     allowedEventTypes:
-      - "librarian:knowledge_update"
+      - "standup:report"
       - "librarian:curation_complete"
 
   # Finance ──────────────────────────────────────────────────────────────
   # Treasurer — financial events
   agent:treasurer:
     allowedEventTypes:
-      - "treasurer:report_ready"
-      - "treasurer:budget_alert"
+      - "standup:report"
+      - "treasurer:low_balance"
+      - "treasurer:spend_report"
 
   # Support ──────────────────────────────────────────────────────────────
   # Guide — support events
   agent:guide:
     allowedEventTypes:
+      - "standup:report"
       - "guide:case_resolved"
-      - "guide:escalation"
+      - "guide:case_escalated"
 
   # Keeper — community moderation events
   agent:keeper:
     allowedEventTypes:
       - "keeper:support_case"
-      - "keeper:moderation_action"
+      - "keeper:community_health"
 
   # System sources ───────────────────────────────────────────────────────
   # AO (the coding agent) — build result events
@@ -113,13 +135,23 @@ sources:
       - "ao:task_blocked"
       - "ao:pr_ready"
       - "ao:spawn_failed"
+      - "ao:pr_merged"
 
   # GitHub webhook handler — github events
   system:webhook:
     allowedEventTypes:
-      - "github:*"
+      - "github:pr_opened"
+      - "github:pr_updated"
+      - "github:issue_assigned"
+      - "github:issue_opened"
+      - "github:issue_labeled"
+      - "github:pr_review_submitted"
+      - "github:pr_review_comment"
+      - "github:ci_pass"
+      - "github:ci_fail"
       - "github:issue_closed"
       - "github:pr_merged"
+      - "github:repository_created"
 
 # Fields that are NEVER allowed in ANY event payload, regardless of schema.
 # These are the exact fields used in the April 2, 2026 attack.

--- a/yclaw-event-policy.yaml
+++ b/yclaw-event-policy.yaml
@@ -10,61 +10,109 @@
 schemaVersion: "1.0"
 
 sources:
-  # Reviewer agent — review-related events only
+  # Executive ────────────────────────────────────────────────────────────
+  # Strategist — strategic directives (wildcard across strategist:* events)
+  agent:strategist:
+    allowedEventTypes:
+      - "strategist:*"
+
+  # Reviewer — review verdicts
   agent:reviewer:
     allowedEventTypes:
       - "reviewer:flagged"
       - "reviewer:approved"
       - "reviewer:rejected"
 
-  # Safety agent — safety events only
-  agent:safety:
-    allowedEventTypes:
-      - "safety:modify"
-      - "safety:alert"
-
-  # Deployer / AO — deploy events only
-  agent:deployer:
-    allowedEventTypes:
-      - "deploy:execute"
-      - "deploy:status"
-      - "deploy:rollback"
-
-  # Architect — build directives and deploy governance
+  # Development ──────────────────────────────────────────────────────────
+  # Architect — build directives, deploy governance, and AO coordination
   agent:architect:
     allowedEventTypes:
       - "architect:build_directive"
       - "architect:repair_directive"
       - "architect:pr_review"
       - "architect:deploy_review"
+      - "architect:design_directive"
+      - "architect:mechanic_task"
+      - "architect:task_complete"
+      - "architect:task_blocked"
       - "deploy:assess"
       - "deploy:approve"
 
-  # Strategist — strategic directives
-  agent:strategist:
+  # Designer — design events
+  agent:designer:
     allowedEventTypes:
-      - "strategist:*"
+      - "designer:review_complete"
+      - "designer:design_update"
+      - "designer:mockup_ready"
 
-  # Sentinel — operational events
-  agent:sentinel:
+  # Mechanic — maintenance events
+  agent:mechanic:
     allowedEventTypes:
-      - "sentinel:alert"
-      - "sentinel:health"
+      - "mechanic:task_complete"
+      - "mechanic:lockfile_updated"
 
+  # Marketing ────────────────────────────────────────────────────────────
   # Ember — content events only
   agent:ember:
     allowedEventTypes:
       - "content:draft"
       - "content:published"
 
-  # Builder / AO — build result events
-  agent:builder:
+  # Forge — asset creation events
+  agent:forge:
     allowedEventTypes:
-      - "builder:task_complete"
-      - "builder:task_failed"
-      - "builder:task_blocked"
-      - "builder:pr_ready"
-      - "builder:spawn_failed"
+      - "forge:asset_ready"
+      - "forge:asset_failed"
+
+  # Scout — research and outreach events
+  agent:scout:
+    allowedEventTypes:
+      - "scout:intel_report"
+      - "scout:outreach_ready"
+      - "scout:competitor_alert"
+
+  # Operations ───────────────────────────────────────────────────────────
+  # Sentinel — operational events
+  agent:sentinel:
+    allowedEventTypes:
+      - "sentinel:alert"
+      - "sentinel:health"
+
+  # Librarian — knowledge management events
+  agent:librarian:
+    allowedEventTypes:
+      - "librarian:knowledge_update"
+      - "librarian:curation_complete"
+
+  # Finance ──────────────────────────────────────────────────────────────
+  # Treasurer — financial events
+  agent:treasurer:
+    allowedEventTypes:
+      - "treasurer:report_ready"
+      - "treasurer:budget_alert"
+
+  # Support ──────────────────────────────────────────────────────────────
+  # Guide — support events
+  agent:guide:
+    allowedEventTypes:
+      - "guide:case_resolved"
+      - "guide:escalation"
+
+  # Keeper — community moderation events
+  agent:keeper:
+    allowedEventTypes:
+      - "keeper:support_case"
+      - "keeper:moderation_action"
+
+  # System sources ───────────────────────────────────────────────────────
+  # AO (the coding agent) — build result events
+  system:ao:
+    allowedEventTypes:
+      - "ao:task_completed"
+      - "ao:task_failed"
+      - "ao:task_blocked"
+      - "ao:pr_ready"
+      - "ao:spawn_failed"
 
   # GitHub webhook handler — github events
   system:webhook:


### PR DESCRIPTION
## Summary

Implements the 5 P0 items from the 2026-04-16 org-audit (`yclaw-org-audit.md`).

- **Event policy reconciled** — removed 3 phantom agents (`safety`, `deployer`, `builder`), added 8 missing real agents (designer, forge, scout, keeper, guide, librarian, mechanic, treasurer), expanded architect scope, added `system:ao`. Now covers all 13 agents + ao + webhook.
- **Gaze scrub** — `prompts/protocol-overview.md` rephrased the "extracted from Gaze Protocol" line. "What We Are Not" negative-space definition preserved.
- **Cron throttle** — architect `stale_issue_sweep` `*/30` → `0 */6`; sentinel `ao_health_check` `*/5` → `*/30`.
- **Ember unfreeze** — 4 content crons released from Dec-31 stubs to production weekday/weekend schedules.
- **Mechanic upgrade** — `claude-sonnet-4-20250514` → `claude-sonnet-4-6`, maxTokens `4096` → `8192`.

## Known follow-up (not in this PR)

The event-policy `allowedEventTypes` follow the audit spec verbatim. A handful of events actually published by agents today (e.g., `standup:report`, `scout:pipeline_report`, `guide:case_escalated`, `keeper:community_health`, `librarian:curation_complete`, `designer:design_review`/`design_generated`, `mechanic:task_completed`/`task_failed`) are NOT in the new policy. Currently this is harmless — `SecurePublisher`/`validateEvent` aren't wired into the live `triggers/event.ts` bus yet. But when enforcement lands, we'll need a second-pass reconciliation (or the P0 publish list needs to be widened). Flagging now so it doesn't bite later.

## Test plan

- [x] `npx tsc -p packages/core/tsconfig.json --noEmit` — clean
- [x] `npm run test --workspace=packages/core -- --run eventbus-security` — 15/15 passed
- [x] YAML syntax validated on all 5 edited YAML files
- [x] Roster check: 13 agents + 2 system sources, 0 phantoms, 0 missing
- [x] Gaze-leak grep on `prompts/protocol-overview.md` — only the intentional "Not a DeFi protocol" negative-space reference remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)