### PR TITLE
fix: Marketing P0 — purge Scout contamination, disable dangerous actions, add missing prompts

### DIFF
--- a/departments/marketing/ember.yaml
+++ b/departments/marketing/ember.yaml
@@ -18,6 +18,8 @@ system_prompts:
   - mission_statement.md
   - chain-of-command.md
   - daily-standup.md
+  - protocol-overview.md
+  - executive-directive.md
   - brand-voice.md
   - review-submission.md
   - content-templates.md
@@ -55,7 +57,7 @@ triggers:
     task: self_reflection
     model:
       provider: anthropic
-      model: claude-sonnet-4-20250514
+      model: claude-sonnet-4-6
       temperature: 0.5
       maxTokens: 4096
 actions:

--- a/departments/marketing/ember.yaml
+++ b/departments/marketing/ember.yaml
@@ -23,6 +23,7 @@ system_prompts:
   - brand-voice.md
   - review-submission.md
   - content-templates.md
+  - content-safety-rules.md
 
 triggers:
   - type: cron

--- a/departments/marketing/ember.yaml
+++ b/departments/marketing/ember.yaml
@@ -70,9 +70,8 @@ actions:
   - twitter:like
   - twitter:retweet
   - twitter:media_upload
-  - twitter:update_profile
-  - twitter:update_profile_image
-  - twitter:update_profile_banner
+  # twitter:update_profile* — moved to Strategist. Profile changes require directive + approval.
+  # Forge creates assets, Strategist executes profile updates via forge:asset_ready pipeline.
   - x:search
   - x:lookup
   - x:user
@@ -97,6 +96,7 @@ event_subscriptions:
 event_publications:
   - standup:report
   - ember:needs_asset
+  - ember:asset_revision_requested
   - ember:content_ready
   - review:pending
 

--- a/departments/marketing/forge.yaml
+++ b/departments/marketing/forge.yaml
@@ -27,6 +27,9 @@ triggers:
     event: ember:needs_asset
     task: create_asset
   - type: event
+    event: ember:asset_revision_requested
+    task: revise_asset
+  - type: event
     event: strategist:slack_delegation
     task: handle_slack_delegation
   - type: event
@@ -62,10 +65,12 @@ event_subscriptions:
   - strategist:forge_directive
   - claudeception:reflect
   - ember:needs_asset
+  - ember:asset_revision_requested
   - strategist:slack_delegation
 event_publications:
   - standup:report
   - forge:asset_ready
+  - forge:asset_failed
 review_bypass: []
 
 heartbeat:

--- a/departments/marketing/forge.yaml
+++ b/departments/marketing/forge.yaml
@@ -14,6 +14,8 @@ system_prompts:
   - mission_statement.md
   - chain-of-command.md
   - daily-standup.md
+  - protocol-overview.md
+  - brand-voice.md
   - design-system.md
   - component-specs.md
   - forge-workflow.md
@@ -35,7 +37,7 @@ triggers:
     task: self_reflection
     model:
       provider: anthropic
-      model: claude-sonnet-4-20250514
+      model: claude-sonnet-4-6
       temperature: 0.5
       maxTokens: 4096
 actions:

--- a/departments/marketing/forge.yaml
+++ b/departments/marketing/forge.yaml
@@ -23,6 +23,12 @@ triggers:
   - type: cron
     schedule: 14 13 * * *
     task: daily_standup
+  - type: cron
+    schedule: "0 10 * * 1"         # Monday 10:00 UTC — weekly asset pack
+    task: weekly_asset_generation
+  - type: cron
+    schedule: "0 9 1 * *"          # 1st of month — profile/banner review
+    task: monthly_brand_review
   - type: event
     event: ember:needs_asset
     task: create_asset

--- a/departments/marketing/scout.yaml
+++ b/departments/marketing/scout.yaml
@@ -22,6 +22,7 @@ system_prompts:
   - executive-directive.md
   - brand-voice.md
   - review-submission.md
+  - content-safety-rules.md
 
 triggers:
   - type: cron

--- a/departments/marketing/scout.yaml
+++ b/departments/marketing/scout.yaml
@@ -28,7 +28,7 @@ triggers:
     schedule: "12 13 * * *"
     task: daily_standup
   - type: cron
-    schedule: "0 8 * * 1-5"
+    schedule: "0 8 * * 1,3,5"     # Mon/Wed/Fri only (was daily)
     task: daily_intel_scan
   - type: cron
     schedule: "0 10 * * 1"

--- a/departments/marketing/scout.yaml
+++ b/departments/marketing/scout.yaml
@@ -18,6 +18,8 @@ system_prompts:
   - mission_statement.md
   - chain-of-command.md
   - daily-standup.md
+  - protocol-overview.md
+  - executive-directive.md
   - brand-voice.md
   - review-submission.md
 
@@ -48,27 +50,31 @@ triggers:
   - type: event
     event: strategist:scout_directive
     task: handle_directive
-  - type: event
-    event: discord:message
-    task: monitor_discord_intel
+  # discord:message trigger DISABLED — too broad, fires on every message.
+  # TODO: Replace with channel-filtered monitoring or hourly digest cron.
+  # - type: cron
+  #   schedule: "0 */2 * * *"
+  #   task: discord_intel_digest
   - type: event
     event: claudeception:reflect
     task: self_reflection
     model:
       provider: anthropic
-      model: claude-sonnet-4-20250514
+      model: claude-sonnet-4-6
       temperature: 0.5
       maxTokens: 4096
 actions:
   - vault:read
   - vault:search
-  - vault:write
+  # vault:write — DISABLED to prevent contaminated intel from corrupting knowledge base.
+  # Scout should publish intel via scout:intel_report event for Strategist review.
   - x:search
   - x:lookup
   - x:user
   - x:user_tweets
   - twitter:read_metrics
-  - email:send
+  # email:send — DISABLED until outreach templates are validated and review gate confirmed.
+  # Scout should draft outreach and submit via review:pending for human approval.
   - discord:get_channel_history
   - event:publish
 

--- a/prompts/audience-personas.md
+++ b/prompts/audience-personas.md
@@ -1,0 +1,33 @@
+# YCLAW Audience Personas
+
+> Who we're talking to. Reference for content creation and outreach.
+
+## Primary: AI Infrastructure Engineers
+
+**Who:** Senior engineers building AI-powered systems at tech companies
+**Pain:** Managing multiple AI agents is chaos — no coordination, no governance, ad-hoc wiring
+**Want:** A production-ready framework that handles the orchestration layer
+**Where:** GitHub, X/Twitter, Hacker News, AI/ML subreddits, tech podcasts
+**Messaging:** Lead with architecture, show production evidence, respect their technical depth
+
+## Secondary: AI-Curious Engineering Leads
+
+**Who:** Engineering managers / tech leads evaluating AI agent approaches
+**Pain:** Team wants to use AI agents but worried about safety, governance, and reliability
+**Want:** Evidence that multi-agent systems can run safely in production with oversight
+**Where:** X/Twitter, tech blogs, conference talks, LinkedIn
+**Messaging:** Lead with governance and safety features, show the approval gate pattern
+
+## Tertiary: Open Source Contributors
+
+**Who:** Developers looking for interesting OSS projects to contribute to
+**Pain:** Want to work on cutting-edge AI but most projects are closed-source or too simple
+**Want:** A well-structured codebase with real architecture to learn from and contribute to
+**Where:** GitHub, Discord, X/Twitter
+**Messaging:** Lead with architecture quality, highlight contribution opportunities, show community
+
+## Anti-personas (NOT our audience)
+
+- **Crypto/DeFi traders** — YCLAW is not a token or protocol
+- **No-code enthusiasts** — YCLAW is developer infrastructure
+- **Enterprise buyers looking for SaaS** — We're open-source, self-hosted

--- a/prompts/category-positioning.md
+++ b/prompts/category-positioning.md
@@ -1,0 +1,41 @@
+# YCLAW Category Positioning
+
+> How YCLAW fits in the AI agent landscape. Reference for all Marketing agents.
+
+## Category
+
+**AI Agent Orchestration Framework** (open source)
+
+## One-line position
+
+"The operating system for AI agent organizations."
+
+## Category definition
+
+AI agent orchestration frameworks provide the infrastructure to run multiple AI agents as a coordinated team. They handle agent coordination, task routing, state management, and governance — the layer between "I have AI agents" and "my AI agents work together safely."
+
+## Where YCLAW sits
+
+| Layer | What It Does | Examples |
+|-------|-------------|---------|
+| Models | Raw AI capability | Claude, GPT, Gemini |
+| Agent SDKs | Single-agent tooling | LangChain, LlamaIndex |
+| **Orchestration** | **Multi-agent coordination** | **YCLAW**, CrewAI, AutoGen, LangGraph |
+| Applications | End-user products | Built on top of orchestration |
+
+## YCLAW's unique angle
+
+1. **Department-based organization** — Agents grouped by function (Marketing, Dev, Ops), not flat lists
+2. **Event-driven coordination** — Typed event bus, not sequential chains or rigid graphs
+3. **Built-in governance** — Approval gates, review pipelines, escalation policies
+4. **Production-proven** — Ran 13 agents autonomously before open-sourcing
+5. **Full framework, not just SDK** — Includes cron, events, actions, skills, departments
+6. **Multi-org agent interop** — Invite other people's AI assistants into your setup. Cross-organization agent collaboration. This is the network effect play that single-tenant frameworks (CrewAI, AutoGen, Claude Cowork) can't match.
+
+## Messaging traps to AVOID
+
+- "AI will replace your team" → Wrong. YCLAW augments, not replaces.
+- "Autonomous AI agents" without governance context → Sounds scary. Always mention approval gates.
+- "Enterprise AI platform" → We're open-source infrastructure, not SaaS.
+- Any DeFi/crypto/token language → YCLAW has nothing to do with blockchain.
+- "Revolutionary" / "game-changing" → Let the architecture speak for itself.

--- a/prompts/component-specs.md
+++ b/prompts/component-specs.md
@@ -1,8 +1,85 @@
-<!-- CUSTOMIZE FOR YOUR ORGANIZATION -->
-
 # Component Specifications
 
 > How each component should look, behave, and animate. Reference this before building any component.
+
+---
+
+## CSS Baselines
+
+Canonical CSS snippets for the three primitive components (card, button, input) plus the float-up animation. Use these values as the source of truth for any variant built on top.
+
+### Card
+
+```css
+.card {
+  background: var(--brand-bg-card);
+  border: 1px solid var(--brand-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  transition: border-color 400ms cubic-bezier(0.4, 0, 0.2, 1),
+              box-shadow 400ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.card:hover {
+  border-color: var(--brand-border-hover);
+  box-shadow: var(--shadow-glow-sm);
+}
+```
+
+### Buttons
+
+```css
+.btn-primary {
+  background: var(--brand-primary);
+  color: var(--brand-text-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+}
+.btn-secondary {
+  background: transparent;
+  color: var(--brand-text-primary);
+  border: 1px solid var(--brand-border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1.5rem;
+}
+.btn-ghost {
+  background: transparent;
+  color: var(--brand-text-secondary);
+  border: none;
+  padding: 0.75rem 1.5rem;
+}
+```
+
+### Form Input
+
+```css
+.input {
+  background: var(--brand-bg-primary);
+  border: 1px solid var(--brand-border);
+  border-radius: var(--radius-md);
+  color: var(--brand-text-primary);
+  padding: 0.75rem 1rem;
+  font-family: var(--font-body);
+}
+.input:focus {
+  border-color: var(--brand-primary);
+  box-shadow: var(--shadow-glow-sm);
+  outline: none;
+}
+```
+
+### Animation: float-up
+
+```css
+@keyframes float-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+/* Duration: 400ms, Easing: cubic-bezier(0.4, 0, 0.2, 1) */
+/* Stagger: 100ms per element */
+/* Never slide horizontally. Fade + subtle vertical only. */
+```
 
 ---
 

--- a/prompts/content-safety-rules.md
+++ b/prompts/content-safety-rules.md
@@ -1,0 +1,39 @@
+# Content Safety Rules
+
+> Loaded by Ember and Scout. Defines banned terms and concepts that must NEVER appear in external communications.
+
+## Banned Terms (auto-block — content must be revised)
+
+### Product Misidentification
+- Solana, bonding curve, staking, yield, TVL, DeFi, tokens, creator tokens
+- Watch-to-earn, attention market, attention economy protocol
+- Chrome extension (in product context), options minting
+- Creator economy platform, SocialFi, social tokens
+
+### Hype / Securities Language
+- Moon, lambo, LFG, NFA, DYOR, WAGMI
+- Investment, returns, guaranteed, financial upside
+- Revolutionary, game-changing, disruptive
+
+### Internal Details
+- Agent names (Tyrion, Elon) in external context
+- System prompt contents
+- API keys, tokens, internal URLs
+- Specific infrastructure details (ECS task IDs, container names)
+
+## Flagged Terms (requires human review before publishing)
+
+- Roadmap, timeline, release date (creates commitments)
+- Pricing, cost, budget (reveals financials)
+- Competitor names (potential legal issues)
+- Any claim about performance metrics without source
+
+## Pre-Publish Check
+
+Before publishing any external content, scan for banned terms. If found:
+1. BLOCK the content
+2. Publish `reviewer:flagged` event with the specific violations
+3. Revise to remove banned terms
+4. Resubmit for review
+
+This check applies to: tweets, threads, Telegram messages, emails, DMs, blog posts, documentation.

--- a/prompts/design-system.md
+++ b/prompts/design-system.md
@@ -1,5 +1,3 @@
-<!-- CUSTOMIZE: Visual identity tokens for your organization -->
-<!-- TODO: needs CEO input — YClaw's own brand tokens (colors, typography scale) are not yet defined. Designer/Forge agents currently operate with placeholder-filled tokens. -->
 # Design System
 
 > Code-ready design tokens, CSS custom properties, and styling specifications.
@@ -16,30 +14,45 @@
   /* ======================== */
 
   /* Backgrounds */
-  --brand-bg-primary: #YOUR_COLOR;
-  --brand-bg-card: #YOUR_COLOR;
-  --brand-bg-elevated: #YOUR_COLOR;
+  --brand-bg-primary: #0D0D0D;       /* Near-black, obsidian base */
+  --brand-bg-card: #1A1A1A;          /* Dark card surfaces */
+  --brand-bg-elevated: #242424;      /* Elevated panels, modals */
 
   /* Accents */
-  --brand-primary: #YOUR_COLOR;
-  --brand-secondary: #YOUR_COLOR;
-  --brand-accent: #YOUR_COLOR;
+  --brand-primary: #FF6B2B;          /* Blaze orange — primary CTA, highlights */
+  --brand-secondary: #FF8F5C;        /* Warm amber — secondary accents */
+  --brand-accent: #FFB088;           /* Soft glow — hover states, subtle warmth */
 
   /* Text */
-  --brand-text-primary: #YOUR_COLOR;
-  --brand-text-body: #YOUR_COLOR;
-  --brand-text-secondary: #YOUR_COLOR;
-  --brand-text-muted: #YOUR_COLOR;
+  --brand-text-primary: #F5F5F5;     /* Near-white — headings, primary text */
+  --brand-text-body: #CCCCCC;        /* Light gray — body text */
+  --brand-text-secondary: #888888;   /* Mid gray — captions, metadata */
+
+  /* Status */
+  --brand-success: #4CAF50;          /* Green — success, approved */
+  --brand-warning: #FF9800;          /* Amber — warning, flagged */
+  --brand-error: #F44336;            /* Red — error, blocked */
+  --brand-info: #2196F3;             /* Blue — informational */
 
   /* Borders */
-  --brand-border: #YOUR_COLOR;
-  --brand-border-hover: #YOUR_COLOR;
+  --brand-border: #333333;           /* Default borders */
+  --brand-border-hover: #FF6B2B;     /* Border on hover — accent warmth */
 
   /* ======================== */
   /* TYPOGRAPHY               */
   /* ======================== */
-  --font-sans: 'Inter', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+
+  --font-display: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  --text-xs: 0.75rem;     /* 12px — captions */
+  --text-sm: 0.875rem;    /* 14px — body small */
+  --text-base: 1rem;      /* 16px — body */
+  --text-lg: 1.125rem;    /* 18px — body large */
+  --text-xl: 1.25rem;     /* 20px — section headers */
+  --text-2xl: 1.5rem;     /* 24px — page headers */
+  --text-3xl: 2rem;       /* 32px — hero headers */
 
   /* ======================== */
   /* SPACING                  */
@@ -54,8 +67,17 @@
   /* RADII                    */
   /* ======================== */
   --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 14px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-full: 9999px;
+
+  /* ======================== */
+  /* SHADOWS                  */
+  /* ======================== */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.4);
+  --shadow-glow-sm: 0 0 8px rgba(255,107,43,0.15);
+  --shadow-glow-lg: 0 0 20px rgba(255,107,43,0.25);
 
   /* ======================== */
   /* ANIMATION                */
@@ -73,30 +95,36 @@
 
 | Role | Font | Weight | Size | Line Height |
 |------|------|--------|------|-------------|
-| Headline | [Font] | [Weight] | [Size] | [Line height] |
-| Subhead | [Font] | [Weight] | [Size] | [Line height] |
-| Body | [Font] | [Weight] | [Size] | [Line height] |
-| Data | [Font] | [Weight] | [Size] | [Line height] |
-| Label | [Font] | [Weight] | [Size] | [Line height] |
+| Headline | Inter | 700 | 2rem (32px) | 1.2 |
+| Subhead | Inter | 600 | 1.5rem (24px) | 1.3 |
+| Body | Inter | 400 | 1rem (16px) | 1.6 |
+| Data | JetBrains Mono | 500 | 0.875rem (14px) | 1.5 |
+| Label | Inter | 500 | 0.75rem (12px) | 1.4 |
 
 ---
 
 ## 3. Component Patterns
 
 ### Cards
-<!-- Define card styling: background, border, radius, hover behavior -->
+Background `--brand-bg-card`, border `1px solid --brand-border`, radius `--radius-md`.
+On hover: border transitions to `--brand-border-hover` with `--shadow-glow-sm`.
 
 ### Buttons
-<!-- Define button variants: primary, secondary, ghost -->
+- **Primary:** `--brand-primary` bg, `--brand-text-primary` text, radius `--radius-md`. Hover: `--shadow-glow-lg`.
+- **Secondary:** transparent bg, `1px solid --brand-border`, `--brand-text-body` text. Hover border: `--brand-border-hover`.
+- **Ghost:** transparent bg + border, `--brand-text-body` text. Hover bg: `--brand-bg-elevated`.
 
 ### Inputs
-<!-- Define form input styling -->
+Background `--brand-bg-elevated`, border `1px solid --brand-border`, radius `--radius-sm`.
+Focus: border `--brand-primary`, `--shadow-glow-sm`.
 
 ---
 
 ## 4. Motion Principles
 
-<!-- Define animation rules: easing, duration, what animates and what doesn't -->
+- **Default easing:** `--ease-default` for all state transitions.
+- **Duration:** `--duration-fast` for hovers, `--duration-normal` for enter/exit, `--duration-slow` for hero animations.
+- **No motion on:** data tables, dense lists, any element that repeats more than 10× on a page.
 
 ---
 
@@ -108,6 +136,3 @@
 @media (min-width: 1024px) { /* lg */ }
 @media (min-width: 1280px) { /* xl */ }
 ```
-
----
-> Customize the tokens above with your organization's brand colors, typography, and component styles.

--- a/skills/ember/humanizer-guide.md
+++ b/skills/ember/humanizer-guide.md
@@ -18,12 +18,12 @@
 ### 3. Significance Inflation
 **Detect:** "It's important to note", "Significantly", "It's worth mentioning", "Notably"
 **Fix:** If it's worth saying, say it. The reader decides importance.
-**YClaw example:** "YClaw rewards attention" not "It's important to note that YClaw rewards attention"
+**YClaw example:** "YClaw orchestrates agents" not "It's important to note that YClaw orchestrates agents"
 
 ### 4. False Depth
 **Detect:** "This raises important questions about", "The implications are far-reaching"
 **Fix:** State the specific implication. No vague gesturing.
-**YClaw example:** "Stakers earn options on floor price" not "This raises important questions about value accrual"
+**YClaw example:** "Departments route events through the approval gate" not "This raises important questions about governance architecture"
 
 ### 5. Performative Nuance
 **Detect:** "It's not that simple", "There are many factors to consider", "This is a complex issue"
@@ -32,7 +32,7 @@
 ### 6. Rule of Three Lists
 **Detect:** Three-item lists used reflexively (especially adjective triplets)
 **Fix:** Use the number of items the content actually needs. Two is fine. Four is fine.
-**YClaw example:** "YClaw makes attention visible and valuable" not "visible, valuable, and verifiable"
+**YClaw example:** "YClaw makes agent coordination visible and governable" not "visible, valuable, and verifiable"
 
 ---
 
@@ -49,12 +49,12 @@
 ### 9. Copula Avoidance
 **Detect:** "serves as", "functions as", "acts as" (instead of "is")
 **Fix:** Use "is" when something IS something.
-**YClaw example:** "YClaw is an attention rewards protocol" not "YClaw serves as an attention rewards protocol"
+**YClaw example:** "YClaw is an AI agent orchestration framework" not "YClaw serves as an AI agent orchestration framework"
 
 ### 10. Hollow Verbs
 **Detect:** "leverage", "utilize", "facilitate", "implement", "optimize"
 **Fix:** "use", "do", "help", "build", "improve"
-**YClaw example:** "Stakers use options to borrow USDC" not "Stakers leverage options to facilitate borrowing"
+**YClaw example:** "Agents use events to coordinate" not "Agents leverage events to facilitate coordination"
 
 ### 11. Hedge Stacking
 **Detect:** "It could potentially", "This might possibly", "may perhaps"
@@ -63,7 +63,7 @@
 ### 12. Passive Voice (Agentless)
 **Detect:** "It has been observed", "It should be noted", "It can be seen that"
 **Fix:** Name the actor or delete. "We noticed" or just state the fact.
-**YClaw example:** "Creators set their payout split" not "The payout split can be configured"
+**YClaw example:** "Operators set the approval gate policy" not "The approval gate policy can be configured"
 
 ---
 
@@ -72,7 +72,7 @@
 ### 13. Uniform Sentence Length
 **Detect:** Multiple sentences of similar length in a row (15-25 words each)
 **Fix:** Vary rhythm. Mix short punches (3-8 words) with longer explanations.
-**YClaw example:** "Watch. Earn. Own the moment." — then follow with a longer sentence.
+**YClaw example:** "Route. Review. Ship." — then follow with a longer sentence.
 
 ### 14. Mechanical Paragraphing
 **Detect:** Every paragraph is 3-4 sentences. Topic sentence, support, conclusion.
@@ -91,9 +91,9 @@
 **Fix:** Let facts carry weight. One emotional beat per piece, maximum.
 
 ### 18. "Landscape" and "Ecosystem"
-**Detect:** "the crypto landscape", "the DeFi ecosystem", "the Web3 space"
-**Fix:** Name the specific thing. "Solana DeFi" not "the DeFi landscape"
-**YClaw example:** "Solana creator tokens" not "the creator token ecosystem"
+**Detect:** "the AI landscape", "the agent ecosystem", "the multi-agent space"
+**Fix:** Name the specific thing. "CrewAI and AutoGen" not "the agent landscape"
+**YClaw example:** "event-driven orchestration frameworks" not "the orchestration ecosystem"
 
 ---
 

--- a/skills/ember/x-algorithm-optimization.md
+++ b/skills/ember/x-algorithm-optimization.md
@@ -71,7 +71,7 @@ Given our brand voice (warm restraint, no exclamation marks, no hype):
 
 ## Validation Notes
 
-*This section tracks what actually works for @YClaw__Protocol vs what the algo says should work.*
+*This section tracks what actually works for @YClaw_ai vs what the algo says should work.*
 *Update after reviewing post performance via x:lookup.*
 
 No data yet — awaiting first content cycle.

--- a/skills/scout/competitor-watchlist.md
+++ b/skills/scout/competitor-watchlist.md
@@ -1,518 +1,165 @@
-# COMPETITOR_WATCHLIST.md
-## YClaw - Competitor Intelligence Document for SIGNAL
+# Competitor Watchlist — YCLAW
 
-**Last Updated:** February 2026
-**Purpose:** Continuous monitoring of competitive landscape in attention/creator economy space
-**Maintained By:** SIGNAL Analytics Agent
-
----
-
-## Executive Summary
-
-YClaw competes at the intersection of:
-- **Attention Economy** - Users rewarded for watching creators
-- **Creator Monetization** - Token-based compensation models
-- **DeFi** - Bonding curves, staking, options trading
-- **Social Tokens** - Creator tokens as stakeable assets
-- **Web3 Social** - On-chain identity and decentralized communities
-
-**Brand Position:** "Attention is underpriced" — YClaw makes attention a tradeable, stakeable asset through Chrome extension rewards.
-
-**Key Differentiator:** Real-time attention rewards (watching = earning options on creator tokens via Solana bonding curve) vs. traditional engagement-based monetization.
+> YCLAW is an open-source AI agent orchestration framework.
+> This watchlist tracks competitors and adjacent projects in the AI agent infrastructure space.
+> Updated by Scout via monthly research cycles.
 
 ---
 
-## 1. DIRECT COMPETITORS
-### (Same Space: Attention/Creator Tokens/SocialFi)
+## What YCLAW Is (For Positioning Context)
+
+YCLAW organizes AI agents into departments with typed event buses, approval gates, and human-in-the-loop governance. Think "Kubernetes for AI agent organizations" — it handles the orchestration, coordination, and safety layer so agent teams can operate autonomously.
+
+**Key differentiators:**
+- Department-based organization (not flat agent lists)
+- Event-driven coordination (not sequential chains)
+- Built-in approval gates and review pipelines
+- Production-tested with 13 agents across 6 departments
+- Open source (not SaaS-locked)
+- **Multi-org agent interop** — YCLAW lets you invite other people's AI assistants into your setup. Not just your agents talking to your agents — cross-organization agent collaboration. This is the network effect play that single-tenant frameworks can't match.
 
 ---
 
-### 1.1 Rally (RLY)
-**Chain:** Ethereum
-**Website:** https://www.rally.io/
-**What They Do:** Creator coins platform. Allows creators to issue branded cryptocurrency tokens and launch NFTs; enables tokenized community economies.
-**Angle:** "Creator Coins on Ethereum" — focuses on monetizing creator-fan relationships through token issuance and community rewards.
-**Community Size:** ~100K+ token holders (approximate)
-**X Handle:** @Rally
-**Token Status:** RLY token; price ~$0.00004-0.000042 USD (heavily diluted)
-**Threat Level:** **MEDIUM**
-- Pioneer in creator coins space (2020s)
-- Established ecosystem with real creator integrations
-- **Weakness:** Token severely underperforming; infrastructure-focused rather than attention-focused; no active user growth signals
+## Direct Competitors (Agent Orchestration Frameworks)
 
-**What YClaw Does Differently:**
-- Turns *attention* (watching) into tradeable assets, not just creator fan loyalty
-- Real-time rewards via browser extension (lower friction)
-- Solana bonding curve model vs. fixed creator coin issuance
-- Options trading angle (derivatives on creator attention, not just base tokens)
+### CrewAI
+- **What:** Multi-agent orchestration framework with role-based agent design
+- **Chain:** Python-based, model-agnostic
+- **GitHub:** github.com/crewAIInc/crewAI
+- **Strengths:** Strong developer adoption, good documentation, role/goal/backstory agent design
+- **Weaknesses:** Less structured than YCLAW (no departments, no event bus), sequential task focus
+- **Threat Level:** HIGH
+- **Track:** GitHub stars, release cadence, enterprise announcements
 
----
+### Microsoft AutoGen
+- **What:** Multi-agent conversation framework from Microsoft Research
+- **GitHub:** github.com/microsoft/autogen
+- **Strengths:** Microsoft backing, research-grade, flexible conversation patterns
+- **Weaknesses:** Complex setup, research-oriented (not production-first), less opinionated architecture
+- **Threat Level:** HIGH
+- **Track:** GitHub activity, Azure integration announcements, enterprise adoption
 
-### 1.2 Friend.tech
-**Chain:** Base (Ethereum L2)
-**Website:** https://www.friend.tech/ (or friend.tech V2)
-**What They Do:** Social token platform where users buy/sell "keys" to creators' attention. Keys unlock 1:1 private messaging with creators.
-**Angle:** "Monetize your influence" — turn social media following into tradeable financial assets.
-**Community Size:** ~574K+ wallet-linked users (per Farcaster data overlap); peaked at 500K+ daily active users in 2023-24
-**X Handle:** @friendtech
-**Token Status:** FRIEND token launched May 2024 at $3, collapsed to $0.03 (99% drawdown)
-**Threat Level:** **LOW** (weakened)
-- **Decline:** Token crash, V2 relaunch shows struggling momentum
-- User retention collapsed after initial hype
-- Keys system is pay-to-chat, not attention-reward based
-- No active creator onboarding signals
+### LangGraph (LangChain)
+- **What:** Stateful multi-agent orchestration built on LangChain
+- **GitHub:** github.com/langchain-ai/langgraph
+- **Strengths:** LangChain ecosystem, good state management, graph-based workflows
+- **Weaknesses:** Tied to LangChain ecosystem, complex for simple use cases
+- **Threat Level:** HIGH
+- **Track:** LangChain ecosystem growth, enterprise customers, LangSmith integration
 
-**What YClaw Does Differently:**
-- Rewards attention *passively* (watch = earn) vs. active purchase of access
-- Bonding curve model creates price discovery; Keys are fixed supply
-- Tied to creator *performance metrics*, not just follower count
-- Options trading vs. simple token trading
+### ElizaOS / Eliza
+- **What:** Open-source AI agent framework, originally for crypto/social agents
+- **GitHub:** github.com/elizaOS/eliza
+- **Strengths:** Large community, plugin ecosystem, social media native
+- **Weaknesses:** Less structured orchestration, crypto-native positioning limits enterprise appeal
+- **Threat Level:** MEDIUM
+- **Track:** GitHub community, plugin ecosystem growth, enterprise pivot signals
 
----
+### OpenAI Agents SDK
+- **What:** Official OpenAI framework for building multi-agent systems
+- **Strengths:** OpenAI model integration, official support, simple API
+- **Weaknesses:** OpenAI model lock-in, less mature than community frameworks
+- **Threat Level:** MEDIUM-HIGH
+- **Track:** Feature releases, model-agnostic moves, enterprise announcements
 
-### 1.3 The Arena (formerly Stars Arena)
-**Chain:** Avalanche
-**Website:** https://www.arena.fun/ (rebranded 2024)
-**What They Do:** SocialFi trading platform. Buy/sell shares in creators ("tickets"). Bonding curve mechanics for creator tokenization. Added launchpad and DEX in V2 (2025).
-**Angle:** "Social trading" — turn creator influence into tradeable assets with bonding curves.
-**Community Size:** ~50K+ active users (estimated post-relaunch); top dApp on Avalanche
-**X Handle:** @TheArenaFun
-**Team:** Led by Jason Desimone (CEO), Phillip Liu Jr (COO) — acquired and rebuilt from Stars Arena security breach (2023)
-**Threat Level:** **MEDIUM-HIGH**
-- **Strength:** Bonding curve model aligns with YClaw's pricing mechanism
-- Strong rebound momentum (V2 launch May 2025, significant adoption)
-- Native DEX + launchpad make Arena a "creator economy hub"
-- Avalanche ecosystem growth tailwind
-- **Weakness:** Social trading focus (speculation) over attention-based rewards; no browser extension or passive reward model
+### Semantic Kernel (Microsoft)
+- **What:** Enterprise AI orchestration SDK with multi-agent patterns
+- **Strengths:** Enterprise-grade, Microsoft ecosystem, .NET/Python/Java support
+- **Weaknesses:** Heavy enterprise focus, less community-driven
+- **Threat Level:** MEDIUM
+- **Track:** Azure AI integration, enterprise case studies
 
-**What YClaw Does Differently:**
-- Passive attention rewards (watch = earn) vs. active trading/speculation
-- Chrome extension distribution (frictionless acquisition vs. DEX interface)
-- Real creator performance metrics (attention time, viewer engagement) as price drivers
-- Options (derivatives) vs. base token trading only
+### Mastra
+- **What:** TypeScript-first AI agent framework
+- **GitHub:** github.com/mastra-ai/mastra
+- **Strengths:** TypeScript native, good DX, workflow engine
+- **Weaknesses:** Newer, smaller community
+- **Threat Level:** MEDIUM
+- **Track:** GitHub growth, TypeScript community adoption
 
----
+### MetaGPT
+- **What:** Multi-agent framework that assigns roles (PM, Engineer, etc.)
+- **GitHub:** github.com/geekan/MetaGPT
+- **Strengths:** Role-based like YCLAW, software development focus
+- **Weaknesses:** Primarily software dev focused, less general-purpose
+- **Threat Level:** LOW-MEDIUM
+- **Track:** GitHub stars, use case expansion beyond dev
 
-### 1.4 Lens Protocol
-**Chain:** Lens Chain (zkSync/Avail-based L2, launched April 2025)
-**Website:** https://lens.xyz/
-**What They Do:** Decentralized social graph protocol. User-owned profiles (NFTs). Portable followers/interactions across apps. Composable social "primitives" (feed, comments, follows).
-**Angle:** "Own your social graph" — decentralized identity & data ownership; protocol for building social apps.
-**Community Size:** ~2M+ profiles; significant developer/creator adoption
-**X Handle:** @LensProtocol
-**Strategic Update:** Transitioned stewardship to Mask Network (Jan 2026); founders Stani/Avara now advisors
-**Threat Level:** **MEDIUM**
-- **Strength:** Massive social graph; zkSync L2 offers low fees; portable identity is unique
-- Strong developer ecosystem for building on top
-- **Weakness:** Protocol focus, not direct creator monetization; no built-in attention rewards; decentralization focus dilutes monetization urgency
-- Mask Network pivot may de-prioritize monetization layer
+### Claude Cowork (Anthropic)
+- **What:** Anthropic's multi-agent collaboration feature within Claude
+- **Strengths:** First-party Anthropic integration, enterprise trust, seamless Claude model access, built-in safety
+- **Weaknesses:** Closed ecosystem, Anthropic-only models, limited customization, no self-hosting
+- **Threat Level:** HIGH
+- **Track:** Product announcements, enterprise adoption, feature expansion, pricing changes
+- **Key difference from YCLAW:** Single-vendor locked vs. YCLAW's model-agnostic open-source approach. No cross-org agent interop.
 
-**What YClaw Does Differently:**
-- Direct creator token + attention rewards vs. just social graph
-- Solana-based for speed/costs (vs. Lens Chain's different L2 choice)
-- Monetization is core, not secondary
-- Bonding curve + options model (financial primitive) vs. social primitive
+### Paperclip
+- **What:** AI agent coordination/workspace platform (emerging)
+- **Strengths:** Fresh approach, active development, growing community
+- **Weaknesses:** Newer, smaller ecosystem, less production-proven
+- **Threat Level:** MEDIUM-HIGH (emerging — watch closely)
+- **Track:** X activity, product launches, funding announcements, feature releases
 
 ---
 
-### 1.5 Farcaster
-**Chain:** Base (Ethereum L2) + Snapchain (offchain social data)
-**Website:** https://warpcast.com/ (primary client)
-**What They Do:** Decentralized social protocol (hybrid: identity on-chain, posts offchain). Feed, follows, casts (tweets). Frames (interactive embeds).
-**Angle:** "Own your social identity" — censorship-resistant, portable social network.
-**Community Size:** ~574K+ wallet-linked users; ~1-2M+ monthly active users
-**X Handle:** @farcasterxyz
-**Recent Pivot (2025-2026):** Acquired Clanker (token deployment tool, Oct 2025); pivoting to **Farcaster Wallet** focus (away from social-first approach)
-**Threat Level:** **LOW-MEDIUM** (in flux)
-- **Strength:** Large, engaged crypto-native community; token trading integrations via Clanker
-- **Weakness:** Founder Dan Romero announced shift away from social features to wallet focus; implies social monetization de-prioritized
-- Recent Neynar acquisition of protocol (Jan 2026) adds uncertainty
-- No native attention rewards or creator token mechanisms
+## Adjacent Projects (Workflow/Infrastructure)
 
-**What YClaw Does Differently:**
-- Attention rewards + creator tokens (monetization) vs. social protocol alone
-- Browser extension + Chrome integration (vs. web/mobile clients)
-- Passive income model (watch = earn) vs. active trading
+| Project | Relevance | Why Track |
+|---------|-----------|-----------|
+| Temporal | Workflow orchestration | Could add agent primitives |
+| n8n | Visual workflow automation | AI agent features expanding |
+| Prefect | Data pipeline orchestration | Similar orchestration patterns |
+| Trigger.dev | Background job framework | TypeScript, could add agent support |
+| Composio | Agent tool integration | Complementary tooling |
 
 ---
 
-### 1.6 Audius
-**Chain:** Polygon + Solana (multi-chain)
-**Website:** https://audius.co/
-**What They Do:** Decentralized music streaming platform. Artists upload/stream music. AUDIO token for staking, governance, tipping.
-**Angle:** "Decentralized music distribution" — artists earn 90% of revenue; no label gatekeepers.
-**Community Size:** ~100K+ creators; millions of listeners
-**X Handle:** @AudiusProject
-**Threat Level:** **LOW** (different use case)
-- **Strength:** Established creator base; sustainable streaming model
-- **Weakness:** Focus on distribution, not token monetization; no attention-based rewards; music-specific (not creator economy generally)
+## Comparison Axes (Track Monthly)
 
-**What YClaw Does Differently:**
-- Attention rewards for *watching* creators (any type) vs. music streaming/download monetization
-- Token options trading vs. revenue sharing model
-- Cross-creator portfolio approach (diversified attention stakes) vs. per-creator subscriptions
-
----
-
-### 1.7 DeSo (Decentralized Social)
-**Chain:** DeSo L1 Blockchain (custom-built)
-**Website:** https://www.deso.com/
-**What They Do:** Layer-1 blockchain for social apps. Enables creator coins, social NFTs, social tipping, social DAOs.
-**Angle:** "Blockchain for social" — high performance infrastructure for social monetization (1-second blocks, 500+ posts/sec).
-**Community Size:** ~100K+ users; moderate creator adoption
-**X Handle:** @DeSoBlockchain
-**Threat Level:** **LOW-MEDIUM** (infrastructure play)
-- **Strength:** Purpose-built for social; high throughput; native creator token mechanics
-- **Weakness:** Limited user adoption; blockchain-specific friction; no attention-reward primitive; competition from EVM chains
-
-**What YClaw Does Differently:**
-- Attention rewards (watching) vs. generic creator monetization tools
-- Solana integration (vs. DeSo's own chain) for liquidity/composability
-- Options/derivatives angle vs. base token only
+| Dimension | What to Measure |
+|-----------|----------------|
+| GitHub stars / growth rate | Community traction |
+| Release cadence | Development velocity |
+| Multi-agent support depth | Feature parity |
+| Event-driven architecture | Architectural similarity |
+| Human approval/gating | Safety/governance features |
+| Deployment model | Self-hosted vs SaaS vs hybrid |
+| Model agnosticism | Provider lock-in risk |
+| Enterprise adoption signals | Market segment overlap |
+| Documentation quality | Developer experience |
+| Plugin/skill ecosystem | Extensibility |
 
 ---
 
-## 2. ADJACENT COMPETITORS
-### (Overlapping but Different Focus)
+## Monitoring Queries (for daily_intel_scan)
+
+### X/Twitter searches:
+- `"CrewAI" (launch OR release OR update OR enterprise)`
+- `"AutoGen" (agent OR multi-agent OR orchestration)`
+- `"LangGraph" (production OR deploy OR enterprise)`
+- `"Claude Cowork" OR "Paperclip AI" OR "AI agent" (new OR launch OR beta)`
+- `"AI agent framework" (open source OR orchestration OR multi-agent)`
+- `"AI agent" (framework OR platform) (launch OR new OR beta) -crypto`
+- `"multi-agent" (framework OR platform OR orchestration)`
+- `"agent orchestration" -crypto -DeFi -token`
+
+### Competitor Discovery (run weekly — new frameworks pop up constantly):
+- `"AI agent" (framework OR platform) (launch OR announcing OR introducing) -crypto -DeFi`
+- `"multi-agent" (open source OR github) (new OR built OR building)`
+- `"agent orchestration" (alternative OR competitor OR vs OR compared)`
+
+### GitHub monitoring:
+- Release tags on competitor repos
+- Star count trends (weekly)
+- New repos in ai-agent-framework topic
+- Trending repos in AI/agents category
 
 ---
 
-### 2.1 Patreon
-**Type:** Web2 Creator Monetization Platform
-**Website:** https://www.patreon.com/
-**What They Do:** Recurring membership/subscription platform for creators. Fans pledge monthly; creators share exclusive content.
-**Fee Model:** 5% (Founders plan), 8% (Pro), 12% (Premium)
-**Creator Base:** ~200K+ creators
-**Threat Level:** **MEDIUM** (market leader in creator subscriptions)
-- **Strength:** Dominant incumbency in recurring creator revenue (~$2B+ annual creator payouts); trusted brand; seamless PayPal/Stripe integration
-- **Weakness:** Web2 (centralized); no token/financial upside for fans; monthly lock-in model (less dynamic than YClaw's real-time rewards)
-
-**Opportunity for YClaw:** Patreon creators are already monetized—*potential migration point if YClaw offers superior rewards or financial upside.*
-
----
-
-### 2.2 Ko-fi
-**Type:** Web2 Creator Monetization Platform (Freemium)
-**Website:** https://ko-fi.com/
-**What They Do:** All-in-one creator platform. Tips, memberships, shop, commissions, goal tracking.
-**Fee Model:** 5% on memberships/merch/sales (or $6/month Ko-fi Gold to avoid fees on tips)
-**Creator Base:** ~1M+ creators
-**Payout Speed:** Real-time (vs. Patreon's monthly)
-**Threat Level:** **MEDIUM** (strongest freemium alternative)
-- **Strength:** Lower barriers (no membership minimum); real-time payouts; diverse monetization (tips + memberships + shop)
-- **Weakness:** Web2; no tokenomics/financial upside for fans
-
-**Opportunity for YClaw:** Ko-fi's 1M creators are even more fragmented in monetization strategies—*targeting Ko-fi creators could yield high conversion if YClaw offers token upside.*
-
----
-
-### 2.3 Twitch
-**Type:** Streaming Platform with Creator Monetization
-**Website:** https://www.twitch.tv/
-**What They Do:** Live streaming + VOD hosting. Monetization: subscriptions (50/50 split, Tier 1-3), Bits (50% split), ads, tipping.
-**Creator Base:** ~9M+ streamers; ~10M+ monthly streamers
-**Threat Level:** **HIGH** (massive market leader)
-- **Strength:** Incumbent streamer audience; strong creator economics (top streamers earn $50K-$200K+/month); integrated monetization
-- **Weakness:** Centralized (Amazon); no creator ownership or tokenomics; 50/50 revenue split is not favorable; attention is *not* directly rewarded (only content quality)
-
-**Opportunity for YClaw:**
-- Twitch streamers are not rewarded for *viewer attention* directly—only final content/subs/bits
-- *YClaw could target Twitch creators by rewarding their audience's attention with token options*
-
----
-
-### 2.4 YouTube
-**Type:** Video Streaming Platform with Creator Monetization
-**Website:** https://www.youtube.com/
-**What They Do:** Video hosting + ads. Creator monetization: YouTube Partner Program (ad revenue share 55/45), memberships, Super Chat/Thanks, donations.
-**Creator Base:** ~500M+ channels; ~490K+ jobs created (2024)
-**Ad Revenue Share:** ~55% to creators (variable)
-**Threat Level:** **HIGH** (dominant video platform)
-- **Strength:** Massive audience; established creator economy; algorithm drives discovery; high ad CPM for quality content
-- **Weakness:** Ad-dependent (volatile); creator has no direct control of earnings (algorithmic); no tokenomics; attention not directly rewarded (only engagement metrics)
-
-**Opportunity for YClaw:**
-- YouTube's algorithmic rewards don't directly compensate for attention
-- *YClaw could layer attention token rewards on top of YouTube ecosystem (cross-platform extension)*
-
----
-
-### 2.5 TikTok
-**Type:** Short-Form Video Platform with Creator Monetization
-**Website:** https://www.tiktok.com/
-**What They Do:** Short-form video (30-60s). Monetization: Creator Rewards Program ($0.40-$1.00 per 1K views; long-form up to $6/1K views), gifts/tips.
-**Creator Base:** ~1B+ users; ~100M+ creators
-**Threat Level:** **HIGH** (dominant short-form platform)
-- **Strength:** Massive reach; algorithm-driven virality; low barrier to monetization (10K followers + 100K monthly views)
-- **Weakness:** Centralized; CPM-based (volatile); regulatory uncertainty (2025-2026 regulatory pressure); no creator ownership; attention not directly rewarded
-
-**Opportunity for YClaw:** TikTok creators are monetized *algorithmically*, not by direct viewer reward. *YClaw could attract TikTok creators with direct viewer-token rewards.*
-
----
-
-### 2.6 Brave / BAT (Basic Attention Token)
-**Type:** Blockchain-Based Attention Token (Different Model)
-**Website:** https://brave.com/
-**What They Do:** Privacy-focused browser. Users earn BAT tokens for viewing privacy-respecting ads. Creators receive BAT from fans/advertisers.
-**Model:** Triangular: Users earn BAT → Pay creators/sites with BAT → Advertisers fund via BAT
-**Community Size:** >100M monthly active users (2025); >1M verified creators
-**BAT Token:** ~$0.24-$0.29 USD; market cap ~$3.5B
-**X Handle:** @BraveSoftware
-**Threat Level:** **MEDIUM** (different but overlapping model)
-- **Strength:** Massive user base (100M+ MAU); established ad/creator ecosystem; real attention tokenization (Brave tracks ad views)
-- **Weakness:** Attention model is *ad-based* (not viewer-driven); focus on privacy ads, not creator token trading; BAT is utility token, not speculative asset
-
-**What YClaw Does Differently:**
-- YClaw rewards attention on *creator content* (watching creators = earning options on creator tokens)
-- Brave rewards attention on *ads* (watching ads = earning BAT)
-- YClaw enables *speculative trading* (options on creator tokens); Brave is utility-based
-- YClaw is creator-centric; Brave is advertiser-centric
-
-**Competitive Dynamic:** Brave and YClaw could theoretically *complement* (both tokenize attention) or *compete* (both vie for user attention time).
-
----
-
-## 3. MONITORING SCHEMA
-
-For each competitor listed above, SIGNAL should track these metrics:
-
-| Metric | Frequency | Primary Source | Alert Threshold |
-|--------|-----------|-----------------|-----------------|
-| **Token Price** | Daily | CoinGecko, CoinMarketCap | >30% drop; +50% gain |
-| **Token Holders** | Weekly | On-chain explorers (Etherscan, Solscan) | New major holder; 10%+ holder dump |
-| **Daily Active Users (DAU)** | Weekly | DeFiLlama, Nansen, project dashboards | >20% drop; +50% spike |
-| **Total Value Locked (TVL)** | Daily | DeFiLlama | >30% drop; new ATH |
-| **Creator Onboarding Rate** | Weekly | Project announcements, social signals | Inflection points (spikes/drops) |
-| **Funding Announcements** | Real-time | Twitter/X, TechCrunch, press releases | Any Series A/B/C or strategic funding |
-| **Partnership/Integration Announcements** | Real-time | Project blog, Twitter, press | Any integration with major platforms |
-| **Feature Launches** | Real-time | Product announcements, app store updates | Feature overlaps with YClaw roadmap |
-| **Team Changes** | As announced | LinkedIn, project announcements | Key departures (CEO, CTO, Head of Products) |
-| **Regulatory Updates** | Real-time | Official announcements, news | Cease-and-desist, license status changes |
-| **Social Media Engagement** | Daily | Twitter followers, Discord members | Trending spikes/drops >20% |
-| **Press Coverage** | Weekly | News aggregators (Cointelegraph, The Block) | Major coverage; mentions of "YClaw" |
-
----
-
-### 3.1 Data Sources for SIGNAL
-
-| Source | Type | API/Access | Frequency |
-|--------|------|-----------|-----------|
-| **CoinGecko / CoinMarketCap** | Token price, market cap, holders | Free API | Real-time (every 5m) |
-| **DeFiLlama** | TVL, protocol metrics | Free API | Real-time |
-| **Etherscan / Solscan / AvaScan** | On-chain data (holders, transfers, contract events) | Free API + explorer | Real-time |
-| **Twitter / X API v2** | Social mentions, engagement, sentiment | Paid API | Real-time |
-| **Discord / Telegram** | Community metrics (member count, message velocity) | Admin access (per community) | Daily |
-| **Project Official Blogs** | Feature announcements, roadmap updates | RSS feed monitoring | As published |
-| **Nansen / Glassnode** | Advanced on-chain analytics | Paid subscriptions | Real-time |
-| **Cointelegraph / The Block** | News aggregation, press coverage | News API + web scraping | Daily |
-
----
-
-## 4. ALERT RULES FOR SIGNAL
-
-SIGNAL should send alerts to the team lead (or escalate to dashboard) when:
-
-### **Tier 1: CRITICAL (Immediate Notification)**
-- [ ] **Competitor raises Series A/B/C funding** → Assess capital runway, growth trajectory
-- [ ] **Competitor launches attention-reward feature** (overlaps with YClaw core mechanic) → Compare implementation, speed to market
-- [ ] **Competitor announces shutdown or major pivot** → Assess if creator base becomes available
-- [ ] **Competitor's token crashes >50%** → Signal potential user/creator exit opportunity
-- [ ] **Competitor integrates with major platform** (e.g., YouTube, Twitch partnership) → Evaluate distribution threat
-- [ ] **YClaw mentioned by competitor** (in tweets, announcements, docs) → Track sentiment, positioning
-
-### **Tier 2: HIGH (Daily Digest)**
-- [ ] **Token price move >30%** (up or down) → Context matters; pair with volume/whale movements
-- [ ] **TVL drop >20%** → Signal potential user exodus
-- [ ] **Creator onboarding rate inflection** → Early signal of momentum shift
-- [ ] **Key team departures** (CEO, Product Lead) → Assess team stability
-- [ ] **Major press coverage** (mainstream news, tech outlets) → Track brand momentum vs. YClaw's
-- [ ] **DAU/Community size drop >20%** → Engagement hemorrhaging
-
-### **Tier 3: MEDIUM (Weekly Summary)**
-- [ ] **Feature announcements that don't directly compete** → Track competitive positioning
-- [ ] **Social media engagement trends** → Community sentiment analysis
-- [ ] **Regulatory updates** (licenses, approvals) → Baseline monitoring
-- [ ] **Partnership announcements** → Assess ecosystem expansion
-
----
-
-## 5. COMPETITIVE POSITIONING MATRIX
-
-**Quick Reference: How YClaw Compares**
-
-| Feature/Dimension | YClaw | Rally | Friend.tech | The Arena | Lens | Farcaster | Brave/BAT | Patreon | YouTube |
-|---|---|---|---|---|---|---|---|---|---|
-| **Chain** | Solana | Ethereum | Base | Avalanche | L2 (Lens Chain) | Base | Multi | Web2 | Web2 |
-| **Token Model** | Options on creator tokens | Creator coins | Key trading | Creator tickets | Social graph (NFT) | Wallet/protocol | BAT utility | N/A | N/A |
-| **Reward Mechanism** | Watch = earn options | Fan-driven purchases | Pay-to-chat | Trade speculation | Portable identity | Wallet focus | Ad views | Monthly pledge | Ad revenue |
-| **Creator Token Trading** | YES (bonding curve) | YES (custom curves) | YES (fixed supply) | YES (bonding curve) | NO | NO (token planned) | NO | NO | NO |
-| **Passive Income** | YES (watch) | NO (trading) | NO (purchase) | NO (trading) | NO | NO | YES (ads) | NO | NO |
-| **Distribution** | Chrome extension | Web/mobile | Web | Web/DEX | Web (Lens apps) | Web (Warpcast) | Browser | Web | Web/App |
-| **User Acquisition Friction** | Low (extension) | Medium | Medium | Medium | High | Medium | Low (browser) | Low | Very low |
-| **Creator Onboarding** | Easy (YClaw handles it) | Medium (complex tokenomics) | Medium | Medium | High (tech-first) | Medium | N/A | Easy | Easy |
-| **Financial Upside for Fans** | HIGH (options trading) | MEDIUM (token appreciation) | MEDIUM (key trading) | HIGH (speculation) | LOW (social only) | LOW | MEDIUM (BAT utility) | LOW | LOW |
-| **Threat Level to YClaw** | — | MEDIUM | LOW | MEDIUM-HIGH | MEDIUM | LOW | MEDIUM | MEDIUM | HIGH |
-
----
-
-## 6. OPPORTUNITY TRIGGERS
-
-Situations where competitors create opportunities for YClaw to recruit creators or accelerate adoption:
-
----
-
-### 6.1 Migration Triggers
-
-| Competitor Event | YClaw Opportunity | Outreach Strategy |
-|---|---|---|
-| **Friend.tech's FRIEND token crashes >80%** | Existing Friend.tech creators lose confidence in platform sustainability | Direct outreach: "YClaw offers more stable, diversified creator monetization" |
-| **Patreon raises subscription fees** | Patreon creators seek alternatives | Positioning: "YClaw complements Patreon—earn while your audience watches, retain your Patreon subs" |
-| **Twitch reduces creator revenue share from 50% to 40%** | Twitch creators seek supplementary revenue | Extension-based pitch: "Earn from every viewer—no sharing split" |
-| **YouTube demonetizes creator due to algorithm changes** | Creator loses ad revenue; seeks supplementary income | Email: "YClaw rewards attention directly—algorithm can't demonetize you" |
-| **The Arena experiences hack or security breach** | Avalanche creators lose trust in smart contracts | Trust-based positioning: "YClaw built with security-first design; audited contracts" |
-| **DeSo chain experiences downtime** | DeSo creators see platform unavailability | Cross-chain positioning: "YClaw operates on Solana—high availability, low latency" |
-
----
-
-### 6.2 Feature Gap Exploitation
-
-| Competitor Weakness | YClaw Advantage | Messaging |
-|---|---|---|
-| **Brave BAT is ad-funded; volatile earnings** | YClaw earnings tied to creator performance (more predictable) | "Earn from creators you believe in—not ad-dependent" |
-| **Lens Protocol has no native monetization** | YClaw has monetization-first approach | "Lens is great for identity; YClaw makes identity profitable" |
-| **Friend.tech only rewards chat access** | YClaw rewards passive watching + active trading | "Get paid to watch creators you love—then trade their tokens" |
-| **Patreon has no speculative upside** | YClaw's bonding curve gives early supporters token appreciation | "Your support could appreciate like an early share" |
-| **YouTube algorithm is opaque** | YClaw metrics are transparent (on-chain) | "See exactly what drives your earnings—full transparency" |
-
----
-
-### 6.3 Community Frustration Signals
-
-**SIGNAL should monitor for these sentiment indicators:**
-
-- [ ] "X platform demonetized me" (Twitter/Reddit threads) → Recruit demonetized creators
-- [ ] "My earnings dropped 50%" (creator communities) → Timing for alternative platform pitches
-- [ ] "X platform fees are too high" (complaints on creator forums) → Benchmark YClaw's fee structure positively
-- [ ] "I was banned for no reason" (support tickets, posts) → Trust/stability narrative
-- [ ] "My followers won't follow me on X platform" (platform switching friction) → Cross-platform positioning
-
----
-
-## 7. THREAT ASSESSMENT SUMMARY
-
-### Competitors by Threat Level (to YClaw)
-
-**CRITICAL THREAT (Immediate Competitive Risk)**
-1. **YouTube** (HIGH) — Massive installed base, algorithmic advantage, trust
-2. **Twitch** (HIGH) — Dominant streaming ecosystem, existing creator/viewer relationships
-3. **Patreon** (MEDIUM-HIGH) — Market leader in creator subscriptions; recurring revenue model
-
-**MODERATE THREAT (Overlapping, but Different Model)**
-4. **The Arena** (MEDIUM-HIGH) — Bonding curve model aligns with YClaw; strong rebound momentum; Avalanche liquidity
-5. **Brave/BAT** (MEDIUM) — Already tokenizes attention; massive user base (100M+ MAU); different angle but overlapping
-6. **Rally** (MEDIUM) — Pioneer in creator coins; established ecosystem; weak token but real integrations
-7. **Lens Protocol** (MEDIUM) — Massive social graph; protocol-first approach could enable monetization layer later
-8. **Ko-fi** (MEDIUM) — 1M+ creators; low barriers; potential migration pool
-9. **DeSo** (LOW-MEDIUM) — Infrastructure play; low user adoption but native creator token mechanics
-
-**LOW THREAT (Different Focus or Weakened)**
-10. **Friend.tech** (LOW) — Token crashed 99%; V2 recovery unlikely; declining momentum
-11. **Farcaster** (LOW-MEDIUM) — Shifting away from social to wallet; uncertain stewardship
-12. **Audius** (LOW) — Music-specific; streaming vs. trading focus
-13. **TikTok** (REGULATORY RISK, not direct threat) — Dominant short-form platform; regulatory uncertainty in 2025-2026 creates *opportunity* if TikTok faces shutdown in key markets
-
----
-
-## 8. YCLAW'S COMPETITIVE MOAT
-
-**What makes YClaw defensible against competitors:**
-
-1. **Chrome Extension Distribution** — Low friction, existing audience habit (vs. visiting new web3 platform)
-2. **Real-Time Attention Rewards** — Immediate, passive earning (vs. trading-based or purchase-based models)
-3. **Bonding Curve + Options** — Hybrid financial primitive (derivatives on attention; not just base token trading)
-4. **Solana Native** — Speed, cost, composability with Solana ecosystem (vs. multi-chain fragmentation)
-5. **Creator Performance Indexing** — YClaw rewards based on actual viewer engagement metrics (vs. social graph or fan loyalty alone)
-6. **Cross-Platform Compatibility** — Works across YouTube, Twitch, Twitter/X, etc. (vs. single-platform competitors)
-
----
-
-## 9. SIGNAL'S MONITORING CHECKLIST
-
-**Daily Tasks (for SIGNAL automation):**
-- [ ] Pull token prices for all competitors from CoinGecko API
-- [ ] Check Twitter mentions of "YClaw" and competitor names
-- [ ] Monitor DeFiLlama for TVL changes (>20% triggers alert)
-- [ ] Check competitor blog RSS feeds for new announcements
-- [ ] Review Cointelegraph/The Block headlines for competitive coverage
-
-**Weekly Tasks:**
-- [ ] Compile user growth metrics (DAU, creator count) from project dashboards
-- [ ] Analyze on-chain data (whale movements, large transfers, contract events)
-- [ ] Social sentiment analysis (Discord, Twitter engagement trends)
-- [ ] Funding round tracking (Crunchbase, AngelList)
-- [ ] Feature release summary (app store updates, blog posts)
-
-**Monthly Tasks:**
-- [ ] Comprehensive competitive positioning review
-- [ ] Creator migration opportunity analysis
-- [ ] Regulatory/compliance updates by jurisdiction
-- [ ] Roadmap analysis (compare public roadmaps to YClaw's)
-- [ ] Report to team lead with strategic recommendations
-
----
-
-## 10. RECOMMENDED ACTIONS FOR TEAM LEAD
-
-**Based on current competitive landscape (Feb 2026):**
-
-1. **Immediate (Next 30 days):**
-   - Accelerate Creator Onboarding for top 100 Twitch/YouTube streamers (YouTube is #1 threat, but Twitch is easier entry point)
-   - Monitor The Arena V2 adoption curve closely (potential Avalanche-to-Solana migration story)
-   - Prepare competitive messaging for Patreon creators (recurring revenue + speculative upside positioning)
-
-2. **Near-term (30-90 days):**
-   - Launch "Attention Rewards" education campaign vs. Brave/BAT (position YClaw as creator-centric vs. ad-centric)
-   - Scout Lens Protocol community for migration potential (large, engaged, but monetization-starved)
-   - Monitor Farcaster's pivot outcome (could be opportunity if wallet focus abandons social monetization)
-
-3. **Medium-term (90-180 days):**
-   - Build cross-platform extension support (YouTube → Twitch → Twitter/X pipeline)
-   - Develop integration partnerships with Patreon, Ko-fi (complement rather than replace)
-   - Prepare for potential YouTube/Twitch revenue share changes (regulatory pressure in 2025-2026)
-
-4. **Strategic:**
-   - Monitor DeSo, Rally, Lens for potential M&A targets (acquire creator base + monetization layer)
-   - Track regulatory landscape for Brave/BAT (if privacy regulations shift, BAT model could weaken)
-   - Prepare for TikTok creator exodus (if ban occurs in 2025-2026); TikTok creators would be excellent YClaw users
-
----
-
-## 11. APPENDIX: SOURCES & REFERENCES
-
-**Data Sources Used (Feb 2026):**
-
-- [CoinGecko - Competitor Token Tracking](https://www.coingecko.com/)
-- [CoinMarketCap - Market Data](https://coinmarketcap.com/)
-- [Rally - Creator Coins](https://www.rally.io/)
-- [Friend.tech - Base Social Token Platform](https://www.friend.tech/)
-- [The Arena - Avalanche SocialFi](https://www.arena.fun/)
-- [Lens Protocol - Decentralized Social](https://lens.xyz/)
-- [Farcaster - Social Protocol](https://warpcast.com/)
-- [Audius - Music Streaming](https://audius.co/)
-- [DeSo - Decentralized Social Blockchain](https://www.deso.com/)
-- [Brave & BAT - Attention Token](https://brave.com/)
-- [Patreon - Creator Subscriptions](https://www.patreon.com/)
-- [Ko-fi - Creator Monetization](https://ko-fi.com/)
-- [Twitch - Streaming Platform](https://www.twitch.tv/)
-- [YouTube - Video Streaming](https://www.youtube.com/)
-- [TikTok - Short-Form Video](https://www.tiktok.com/)
-- [DeFiLlama - TVL & Protocol Data](https://defillama.com/)
-- [The Block - Research & News](https://www.theblock.co/)
-- [Cointelegraph - Crypto News](https://cointelegraph.com/)
-
----
-
-**Document Version:** 1.0
-**Next Review Date:** March 2026
-**Maintained By:** SIGNAL Analytics Agent
-**Last Updated:** February 11, 2026
+## What YCLAW Is NOT (Positioning Guardrails)
+
+When comparing YCLAW to competitors, NEVER:
+- Describe YCLAW as a DeFi protocol, Solana project, or token platform
+- Compare against crypto/SocialFi projects (Rally, Friend.tech, etc.)
+- Use terms: bonding curve, staking, yield, TVL, watch-to-earn, creator tokens
+- Frame as consumer app — YCLAW is developer infrastructure

--- a/skills/scout/outreach-templates.md
+++ b/skills/scout/outreach-templates.md
@@ -1,391 +1,162 @@
-# YClaw Outreach Templates
+# Outreach Templates — YCLAW
 
-**SCOUT Growth AI Agent — Personalized Outreach Library**
-
-All messages go through the team lead's approval before sending. These templates emphasize the attention economy thesis, avoid financial promises, and maintain YClaw's warm restraint voice.
-
----
-
-## Template 2: Creator Cold DM — X (Twitter)
-
-**Platform:** X Direct Message
-**Use case:** Outreach to crypto-native creators, founders, and builders with technical credibility (5k-100k followers)
-**Personalization required:** Creator's handle, recent threads/posts, their main focus area, evident technical depth
-**Approval:** Always requires team lead approval
-
-### Template
-
-{{creator_handle}},
-
-Your {{topic_reference}} thread last week—the part about {{specific_insight}}—that's exactly the problem YClaw solves.
-
-We're building on Solana. Creators mint a token when they stream/create. Audience stakes to watch. Direct attention capture. No platform tax.
-
-You already understand why attention markets matter. Curious what you think.
-
-{{your_handle}}
-
-### Personalization Guide
-
-- **{{creator_handle}}**: Their X handle (with @)
-- **{{topic_reference}}**: What they post about (NFTs, tokenomics, creator economy, protocol design, etc.)
-- **{{specific_insight}}**: Quote or paraphrase ONE specific, substantive point from their recent thread that relates to attention or creator economics
-- **{{your_handle}}**: Your X handle
-
-Research before sending:
-- Last 10 posts (what's their expertise?)
-- Retweets/engagement (what resonates with them?)
-- Any public criticism of platforms or creator tools
-- Evidence of technical depth (do they understand tokenomics, bonding curves, incentive design?)
-- Are they founder/builder in crypto space?
-
-### Do NOT
-
-- Use "!!" or excessive punctuation
-- Claim YClaw is "revolutionary" or "the future"
-- Ask for a call immediately
-- Oversimplify tokenomics
-- Reference things from more than 2 weeks ago
-- DM without reading their recent posts first
-- Mention token price or financial upside
-
-### Follow-up Rules
-
-- One DM only
-- If no reply in 5 days, monitor their feed and reply to a future relevant post instead (public reply > follow-up DM)
-- Track: date sent, whether they're actively posting, any public response
+> Templates for developer relations, community building, and partnership outreach.
+> All outreach must go through review:pending before sending.
 
 ---
 
-## Template 4: Protocol Partnership Intro — X/Telegram
+## Template 1: Open Source Contributor Outreach
 
-**Platform:** X Reply or Telegram Direct Message
-**Use case:** Outreach to crypto protocols, DAOs, infrastructure projects, exchanges (potential collaborators, not audiences)
-**Personalization required:** Protocol name, recent product launch/announcement, their user base size, explicit smart contract focus
-**Approval:** Always requires team lead approval
+**Use when:** Reaching out to developers who might contribute to YCLAW
+**Channel:** GitHub discussion, X DM, or email
+**Review tier:** Tier 2 (requires Reviewer approval)
 
-### Template
+```
+Subject: Contributing to YCLAW — [specific area]
 
-Hey {{partner_name}},
+Hi [name],
 
-{{protocol_name}} is interesting because {{specific_reason}}. We think there's a natural fit with YClaw.
+I came across your work on [their project/contribution] — really solid [specific thing you noticed].
 
-We're building an attention market on Solana—creators mint tokens when content goes live, audience stakes to watch. Direct incentive alignment between creator and viewer.
+We're building YCLAW, an open-source framework for running AI agent organizations. Think departments, event buses, approval gates — the orchestration layer so agent teams can actually operate in production.
 
-The connection: {{reason_why_partnership_makes_sense}}. Would be worth exploring.
+We have an open issue ([link]) in [area that matches their expertise] and I think your experience with [their skill] would be a great fit.
 
-Curious if this lands for you. {{your_name}}
+No pressure — just wanted to put it on your radar. Happy to answer any questions about the architecture.
 
-### Personalization Guide
-
-- **{{partner_name}}**: Founder, protocol lead, or BD contact (use first name)
-- **{{protocol_name}}**: Their protocol name
-- **{{specific_reason}}**: What they do and why it matters technically (not hype)
-- **{{reason_why_partnership_makes_sense}}**: How YClaw users could benefit from their protocol, or how their users could benefit from YClaw (e.g., "Your staking community already thinks in attention incentives")
-- **{{your_name}}**: Full name and title
-
-Research before sending:
-- Their recent product launches or updates
-- How many users/TVL
-- Their positioning in the market (not generic—what's unique?)
-- Any public statements about creator economy or attention
-- Discord/community tone (are they builder-focused or hype-focused?)
-- Timing (are they actively building or in decline?)
-
-### Do NOT
-
-- Lead with "partnership opportunity" (too corporate)
-- Promise user growth or traffic
-- Oversell YClaw before they understand it
-- Copy/paste to multiple protocols
-- Mention token economics unless they ask
-- Use corporate speak ("synergies", "leverage", "market-leading")
-- Propose something vague ("let's collaborate")
-
-### Follow-up Rules
-
-- One outreach message only
-- If no response in 10 days, send ONE follow-up with new relevant news (e.g., if you launch a feature that affects them, reference it)
-- If still no response, note it and move on; partnerships require mutual recognition
-- Track: date, recipient, reason for partnership fit, response time
+[sign-off]
+```
 
 ---
 
-## Template 5: Formal Partnership Proposal — Email
+## Template 2: Technical Integration Partnership
 
-**Platform:** Email
-**Use case:** Follow-up to initial partnership interest or inbound inquiry; requires more detail, structured proposal
-**Personalization required:** Organization name, their specific business model, how YClaw could create mutual benefit, decision-maker title
-**Approval:** Always requires team lead approval
+**Use when:** Proposing integration with complementary AI tools
+**Channel:** Email or X DM
+**Review tier:** Tier 2
 
-### Template
+```
+Subject: YCLAW + [their tool] integration
 
----
+Hi [name],
 
-**Subject:** Attention Market Integration — YClaw + {{partner_name}}
+I'm reaching out from YCLAW — we're an open-source AI agent orchestration framework (departments, event buses, approval gates for autonomous agent teams).
 
-Dear {{decision_maker_name}},
+Our users keep asking about [their tool] integration, specifically for [use case]. We think there's a natural fit:
 
-Thank you for taking our call last {{day}}. Per our conversation, I'm outlining how YClaw could integrate with {{partner_name}}'s {{product_line}}.
+- YCLAW handles agent coordination and governance
+- [Their tool] handles [their strength]
+- Together: [specific user benefit]
 
-**The Thesis**
+Would you be open to a quick call to explore this? We could start with a community integration and see where it goes.
 
-Attention is priced inefficiently across platforms. Viewers spend hours engaging with creators, but creators see only a fraction of the economic value generated. YClaw corrects this: creators mint tokens on Solana; viewers stake to watch; the creator captures attention value directly.
+[GitHub link] if you want to poke around the architecture first.
 
-**Why This Matters for {{partner_name}}**
-
-{{specific_value_prop}} would benefit {{their_audience_description}} because {{outcome}}.
-
-Concretely:
-- {{integration_point_1}}
-- {{integration_point_2}}
-- {{integration_point_3}}
-
-**Next Steps**
-
-We're launching {{milestone}} on {{date}}. I'd suggest we:
-1. Align on {{specific_deliverable}} by {{date}}
-2. Draft integration terms by {{date}}
-3. Run a pilot with {{scope}} in {{timeframe}}
-
-**Timeline**
-
-{{your_timeline_here}}
-
-I'm attaching our protocol documentation and initial integration spec. Happy to jump on a call {{available_times}}.
-
-Best,
-{{your_full_name}}
-{{your_title}}
-YClaw
-{{contact_info}}
+[sign-off]
+```
 
 ---
 
-### Personalization Guide
+## Template 3: Conference / Meetup Speaking Proposal
 
-- **{{partner_name}}**: Organization name
-- **{{decision_maker_name}}**: Their actual name (confirm title)
-- **{{day}}**: When you talked ("Tuesday" is fine; no "last week")
-- **{{product_line}}**: What they build/sell
-- **{{specific_value_prop}}**: How YClaw creates value for their specific users/business model (1-2 sentences, concrete)
-- **{{their_audience_description}}**: Who their users are
-- **{{outcome}}**: The tangible result (not "better engagement"—something specific like "creators earn {{X}}% more per hour")
-- **{{integration_point_1-3}}**: Three specific, actionable ways YClaw works with their product
-- **{{milestone}}**: Your next product launch or feature
-- **{{date}}**: Realistic date
-- **{{scope}}**: Pilot scope (e.g., "10 creators from your network")
-- **{{timeframe}}**: How long the pilot runs
-- **{{your_timeline_here}}**: Specific dates for each step
-- **{{available_times}}**: Your actual availability (time zone + a few specific slots)
+**Use when:** Submitting CFPs or requesting speaking slots
+**Channel:** CFP form or organizer email
+**Review tier:** Tier 2
 
-Research before sending:
-- Their business model (how do they make money?)
-- Their user base (size, type, engagement patterns)
-- Any public statements on creator economy
-- Their recent funding, hires, or announcements
-- Competitive landscape (who else might they partner with?)
-- Their approval process (who actually decides?)
+```
+Title: Running an AI Agent Organization: Departments, Event Buses, and What Breaks at Scale
 
-Attach:
-- 1-2 page protocol summary (not a long whitepaper)
-- Technical integration spec (even if rough)
-- Visual diagram of how integration works
+Abstract: What happens when you give 13 AI agents real responsibilities and let them coordinate autonomously? We built YCLAW — an open-source framework where agents are organized into departments, communicate through typed event buses, and pass content through approval gates before it reaches the outside world.
 
-### Do NOT
+This talk covers:
+- Why flat agent lists don't scale (and what departments solve)
+- Event-driven coordination vs. sequential chains
+- The approval gate pattern: how agents police each other
+- What actually breaks when you run 13 agents in production
+- Open-source lessons: building agent infrastructure as a community
 
-- Use "world-changing" or superlatives
-- Promise specific financial returns
-- Write more than 1 page of body text (keep it to 4-5 short paragraphs)
-- Include token price or price projections
-- Ask them to sign an NDA before explaining the concept
-- Be vague about what integration means
-- Use "exciting opportunity" (show, don't tell)
-- Over-format or make it visually cluttered
-
-### Follow-up Rules
-
-- Send once per decision-maker
-- If no response in 10 days, send ONE follow-up referencing a specific news item or milestone
-- If they go silent after 2 touches, escalate to their investors/board members only with explicit permission
-- Track all interactions; note decision timeline and objections
-- If rejected, ask for feedback and don't re-approach for 6 months
+Speaker bio: [customize]
+```
 
 ---
 
-## Template 6: Conference/Event Follow-up — Email
+## Template 4: Tech Podcast / Newsletter Outreach
 
-**Platform:** Email
-**Use case:** After meeting someone in person at a conference, demo day, or industry event
-**Personalization required:** Their name, specific conversation topic, their company/project, relevant detail from your conversation
-**Approval:** Always requires team lead approval
+**Use when:** Pitching to AI/tech content creators
+**Channel:** Email or X DM
+**Review tier:** Tier 2
 
-### Template
+```
+Subject: Story pitch — What running 13 autonomous AI agents taught us
 
----
+Hi [name],
 
-**Subject:** Great talking with you at {{event_name}} — {{one_word_topic}}
+Love what you're doing with [their show/newsletter] — [specific recent episode/issue you liked].
 
-Hi {{first_name}},
+We have a story that might interest your audience: we built an open-source framework (YCLAW) that organizes AI agents into departments — marketing, development, operations — with event buses and approval gates. It's been running 13 agents autonomously in production.
 
-Really enjoyed our conversation at {{event_name}} yesterday about {{specific_topic_you_discussed}}. Your point about {{their_specific_comment}} has stuck with me.
+The interesting bits:
+- Agents reviewing each other's work before it goes public
+- What happens when an agent goes off-script (and how governance catches it)
+- Why we open-sourced it (and what the community is building)
 
-I promised to send over {{what_you_said_you'd_send}}. Attached.
+Happy to do a deep-dive interview or provide a written piece. Whatever format works best for you.
 
-One thing I didn't get to: your work with {{their_project}} seems like a natural fit for what we're building. Not in an aggressive way—just that the attention economics problem you're solving is the same one YClaw targets from the creator side.
-
-If {{next_logical_step}} makes sense, I'm game. No pressure either way.
-
-Talk soon,
-{{your_first_name}}
-
----
-
-### Personalization Guide
-
-- **{{event_name}}**: Conference, meetup, or event name
-- **{{first_name}}**: Their first name
-- **{{specific_topic_you_discussed}}**: What you actually talked about (be specific—not "crypto" but "token incentive design for retention")
-- **{{their_specific_comment}}**: Quote or paraphrase something they said that was thoughtful or novel
-- **{{what_you_said_you'd_send}}**: Honor any promise you made (protocol docs, a blog post, an intro, etc.)
-- **{{their_project}}**: What they're building
-- **{{next_logical_step}}**: One small, concrete action (coffee call, intro to someone, demo in 2 weeks, etc.)
-- **{{your_first_name}}**: Just your first name
-
-Research before sending:
-- Review what they said during the conversation (take notes during events)
-- Check their LinkedIn/X for recent updates since the event
-- Confirm their correct email and title
-- Send within 24 hours of the event (while you're fresh to them)
-
-### Do NOT
-
-- Wait more than 2 days to send
-- Be generic ("great meeting you")
-- Propose a major partnership in the first follow-up
-- Ignore what they told you about their business
-- Use the message to pitch hard
-- Send the same follow-up to everyone from the event
-- Attach unsolicited documents (only what you promised)
-- Follow up with a question they should know the answer to
-
-### Follow-up Rules
-
-- One email only after the event
-- If they respond positively, move to their preferred communication channel (Telegram, X, Slack)
-- If no response in 7 days, do NOT email again
-- If they say "not a fit," don't follow up
-- If they seem lukewarm but interested, set a specific next meeting time in the first email
+[sign-off]
+```
 
 ---
 
-## Template 7: Ambassador Invitation — Telegram
+## Template 5: Design Partner Recruitment
 
-**Platform:** Telegram Direct Message
-**Use case:** Reaching out to highly engaged community members, small creators, or respected voices who understand YClaw and could amplify it authentically
-**Personalization required:** Their name, their audience/influence, specific evidence of their engagement with similar projects, what they've already said about attention/incentives
-**Approval:** Always requires team lead approval
+**Use when:** Finding teams to beta test new YCLAW features
+**Channel:** Email or community channels
+**Review tier:** Tier 2
 
-### Template
+```
+Subject: Design partner opportunity — [feature name]
 
-Hey {{first_name}},
+Hi [name],
 
-I've been following your take on {{topic_area}} for a while—you get why attention markets matter, which is rare.
+We're building [feature] for YCLAW (our open-source agent orchestration framework) and looking for 3-5 design partners to shape it.
 
-We're launching an ambassador program for YClaw. Nothing complicated: creators and engaged community members who believe in the thesis and can talk about it authentically.
+What we're building: [1-2 sentences on the feature]
+What we need: Teams running multi-agent systems who can test, give feedback, and help us get the API right.
+What you get: Early access, direct input on the design, and credit in the release.
 
-You'd get early access to features, direct line to us, and a small allocation to have skin in the game. We're only bringing on people who actually care about the problem, not just promotion.
+Interested? Happy to share the RFC and get you set up.
 
-Sound like something worth exploring?
-
-{{your_name}}
-
-### Personalization Guide
-
-- **{{first_name}}**: Their first name
-- **{{topic_area}}**: What they consistently talk/think about (tokenomics, creator economy, incentive design, Solana ecosystem, etc.)
-- **{{your_name}}**: Your first name or casual handle
-
-Research before sending:
-- Have they been amplifying similar projects? (Check their posts, retweets, mentions)
-- What's their actual audience size? (Follower count matters less than influence)
-- Do they comment meaningfully, or just retweet hype?
-- Have they ever criticized attention/platform economics?
-- What's their credibility in their niche?
-- Are they actually a creator themselves, or a community builder, or an investor?
-
-### Do NOT
-
-- Offer financial compensation directly (say "allocation" instead)
-- Promise them earnings
-- Say they're "perfect" for this (too generic)
-- Ask for a commitment before they understand the role
-- Invite them just because they have a big following
-- Use "ambassador" if you mean "promoter"—ambassadors shape strategy
-- Make it sound like MLM or network marketing
-
-### Follow-up Rules
-
-- One message only
-- If they seem interested, move to a Zoom call within 1 week
-- If no response in 5 days, do NOT follow up
-- If they ask about specifics (commission, token allocation, expectations), have answers ready before the call
-- Track: date invited, response, whether they convert to active ambassador
+[sign-off]
+```
 
 ---
 
-## Master Guidelines for All Templates
+## Template 6: Follow-Up (Warm)
 
-### Tone & Voice
+**Use when:** Following up with someone who expressed interest but hasn't responded
+**Channel:** Same as original outreach
+**Review tier:** Tier 1 (can send autonomously if original was approved)
 
-- **Warm restraint**: Knowledgeable, not hyped. Confident, not cocky.
-- **No exclamation marks** in any template
-- **Reference specific work**: Always cite something concrete they've made or said
-- **Lead with thesis**: Attention is mispriced; YClaw lets you price it. Not "join Web3" or "earn tokens"
-- **Never promise returns**: Talk about incentive alignment and capture, not financial gains
-- **Personalization first**: Generic templates are flags for SCOUT to reject
+```
+Subject: Re: [original subject]
 
-### Research Before SCOUT Sends
+Hi [name],
 
-Before any outreach:
-1. Verify the person/protocol is real and active (no dead accounts)
-2. Read their 5-10 most recent posts/content pieces
-3. Identify ONE specific thing you genuinely respect about their work
-4. Know their audience size, niche, and engagement patterns
-5. Confirm contact info is current and correct
-6. Check if they've publicly criticized platforms or praised attention-aligned concepts
+Just bumping this in case it got buried. No worries if the timing isn't right — happy to reconnect whenever works.
 
-### Approval Workflow
+[1 sentence reminder of what you proposed]
 
-1. **SCOUT drafts** using the template structure
-2. **SCOUT personalizes** with research data
-3. **SCOUT flags questions** if information is missing
-4. **Team lead reviews** the draft message (no changes without approval)
-5. **Team lead approves or requests edits** (max 2 rounds)
-6. **Message sends** only after explicit approval
-7. **Log everything**: date sent, who, platform, personalization details used, response
-
-### What SCOUT Should Reject
-
-- Any template where personalization is missing or generic
-- Outreach to inactive accounts (no posts in 30+ days)
-- Creators with <5k followers on socials (wrong stage)
-- Protocols that are rug-pulls, inactive, or in legal trouble
-- Messages that mention token price, financial returns, or hype language
-- Any follow-ups without team lead approval on the original
-
-### Response Tracking
-
-Track every outreach in a log:
-- Date & time sent
-- Recipient (name, platform, handle)
-- Template used
-- Personalization details
-- Response (yes/no/maybe, date, next step)
-- Follow-up date (if applicable)
+[sign-off]
+```
 
 ---
 
-**Last Updated:** February 2026
-**Team Lead Approval Required:** Yes, for all outreach
-**Responsible Agent:** SCOUT Growth AI
+## Outreach Rules
+
+1. **All first-touch outreach requires Reviewer approval** (publish `review:pending`)
+2. **Never claim capabilities we haven't shipped**
+3. **Never compare YCLAW to crypto/DeFi/SocialFi projects**
+4. **Max 5 outreach messages per day** (avoid spam patterns)
+5. **Track all outreach in vault** (prospect name, date, channel, status)
+6. **Follow-ups:** Max 2 follow-ups per prospect, spaced 1 week apart
+7. **If someone says no or doesn't respond after 2 follow-ups, stop**

--- a/skills/scout/x-research.md
+++ b/skills/scout/x-research.md
@@ -111,11 +111,11 @@ Keep `max_results` at 10 unless deeper research is needed. 24-hour deduplication
 
 ## Competitive Intel Targets
 
-Key accounts and topics to monitor for YClaw-relevant intel:
-- **Attention economy**: `"attention economy" OR "creator tokens" OR "watch to earn"`
-- **Solana ecosystem**: `"solana" (creator OR attention OR token)` 
-- **Competitors**: Search for specific competitor names and products
-- **AI agents**: `"AI agents" (crypto OR web3 OR autonomous)`
-- **Creator economy**: `"creator economy" (blockchain OR token OR decentralized)`
+Key accounts and topics to monitor for YCLAW-relevant intel:
+- **AI agent frameworks**: `"AI agent framework" (open source OR orchestration OR multi-agent)`
+- **Direct competitors**: `"CrewAI" OR "AutoGen" OR "LangGraph" (launch OR update OR enterprise)`
+- **Multi-agent systems**: `"multi-agent system" (production OR deploy OR scale)`
+- **Agent orchestration**: `"agent orchestration" -crypto -DeFi -token`
+- **AI agent governance**: `"AI agents" (department OR coordination OR approval OR governance)`
 
 Update this list as the competitive landscape evolves.

--- a/yclaw-event-policy.yaml
+++ b/yclaw-event-policy.yaml
@@ -73,6 +73,7 @@ sources:
     allowedEventTypes:
       - "standup:report"
       - "ember:needs_asset"
+      - "ember:asset_revision_requested"
       - "ember:content_ready"
       - "review:pending"
       # Universal content review gate (P2) — kept alongside ember:content_ready for compat.
@@ -83,6 +84,7 @@ sources:
     allowedEventTypes:
       - "standup:report"
       - "forge:asset_ready"
+      - "forge:asset_failed"
 
   # Scout — research and outreach events
   agent:scout:


### PR DESCRIPTION
## Summary

Marketing department P0 fixes from the 2026-04-16 audit. Scout was catastrophically contaminated — all 3 skill files described YCLAW as a Solana DeFi/attention-economy protocol. Blocks external Marketing execution until merged.

### Task 1 — Scout skills rewritten
- `competitor-watchlist.md` deleted + rewritten for AI agent framework space (CrewAI, AutoGen, LangGraph, ElizaOS, OpenAI Agents SDK, Mastra, MetaGPT, Claude Cowork, Paperclip) with positioning guardrails
- `outreach-templates.md` deleted + rewritten with 6 DevRel/OSS templates (contributor outreach, integration partnerships, CFPs, podcast pitches, design partners, follow-ups) — all tagged review tier
- `x-research.md` Competitive Intel Targets rescoped from DeFi queries to AI agent framework queries

### Task 2 — Scout dangerous actions disabled
- `email:send` DISABLED (cold email spam/legal risk)
- `vault:write` DISABLED (prevent contaminated intel corrupting knowledge base)
- `discord:message` trigger DISABLED (fires on every message — too broad; TODO: channel-filtered or hourly digest cron)

### Task 3 — Ember skills scrubbed
- `humanizer-guide.md`: 9 DeFi example lines rewritten ("YClaw rewards attention" → "YClaw orchestrates agents", "Stakers earn options on floor price" → department/event example, "attention rewards protocol" → "AI agent orchestration framework", etc.)
- `x-algorithm-optimization.md`: `@YClaw__Protocol` → `@YClaw_ai`

### Task 4 — Missing system prompts added
| Agent | Added | New Total |
|---|---|---|
| Ember | protocol-overview, executive-directive | 8→10 |
| Forge | protocol-overview, brand-voice | 8→10 |
| Scout | protocol-overview, executive-directive | 7→9 |

### Task 5 — Model override refresh
All 3 agents: `claude-sonnet-4-20250514` → `claude-sonnet-4-6` on `claudeception:reflect`.

## Out-of-scope residue (for P1/P2)
- `skills/scout/x-research.md:59,93` references `github:get_contents` and `github:commit_file` but Scout's actions list lacks them (pre-existing drift; P0 spec only scoped Competitive Intel Targets section)
- `skills/ember/README.md:3` still contains `@YClaw__Protocol` (P0 Task 3 scope was x-algorithm-optimization.md + humanizer-guide.md only)

## Test plan
- [x] All YAMLs parse cleanly (Ember 10/10/23, Forge 10/5/16, Scout 9/8/9)
- [x] `config-validation.test.ts` + `onboarding-validation.test.ts` → 19/19 passing
- [x] Zero real contamination (4 hits in competitor-watchlist.md are intentional negative-space guardrails: `-DeFi` search exclusions and "YCLAW is NOT" banned-term list)
- [x] No `claude-sonnet-4-20250514` refs remain in `departments/marketing/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)