### PR TITLE
fix(dev): P0 critical fixes — security, heartbeat, Slack/Discord, placeholders

### DIFF
--- a/.github/workflows/agent-config-lint.yml
+++ b/.github/workflows/agent-config-lint.yml
@@ -1,0 +1,69 @@
+name: Agent Config Lint
+on:
+  pull_request:
+    paths:
+      - 'departments/**'
+      - 'prompts/**'
+      - 'skills/**'
+
+jobs:
+  lint-agent-configs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for unresolved placeholders
+        run: |
+          echo "Checking for unresolved placeholders..."
+          FOUND=0
+
+          if grep -rn '\[your-' departments/ prompts/ skills/ --include='*.md' --include='*.yaml' --include='*.yml'; then
+            echo "❌ Found [your-*] placeholders"
+            FOUND=1
+          fi
+
+          if grep -rn 'your-org' departments/ prompts/ skills/ --include='*.md' --include='*.yaml' --include='*.yml'; then
+            echo "❌ Found your-org references"
+            FOUND=1
+          fi
+
+          if grep -rn '<!-- CUSTOMIZE' departments/ prompts/ skills/ --include='*.md'; then
+            echo "❌ Found CUSTOMIZE markers"
+            FOUND=1
+          fi
+
+          if grep -rn 'your-landing\|your-style-guide\|your-brand-voice' departments/ prompts/ skills/ --include='*.md'; then
+            echo "❌ Found template placeholders"
+            FOUND=1
+          fi
+
+          if [ $FOUND -eq 1 ]; then
+            echo ""
+            echo "Unresolved placeholders found. Please replace with actual values."
+            exit 1
+          fi
+
+          echo "✅ No placeholders found"
+
+      - name: Check for Slack/Discord mismatch
+        run: |
+          echo "Checking for Slack references in prompt files..."
+          if grep -rni 'slack' prompts/ --include='*.md' | grep -v '<!-- .* -->' | grep -vi 'no.slack'; then
+            echo "⚠️ Found Slack references in prompts — verify these should not be Discord"
+            # Warning only, not blocking
+          else
+            echo "✅ No unexpected Slack references"
+          fi
+
+      - name: Check for old model names
+        run: |
+          echo "Checking for deprecated model names..."
+          FOUND=0
+          if grep -rn 'claude-sonnet-4-20250514\|claude-3-opus\|claude-3-sonnet' departments/ --include='*.yaml' --include='*.yml'; then
+            echo "❌ Found deprecated model names"
+            FOUND=1
+          fi
+          if [ $FOUND -eq 1 ]; then
+            exit 1
+          fi
+          echo "✅ All model names current"

--- a/departments/development/README.md
+++ b/departments/development/README.md
@@ -76,20 +76,35 @@ Mechanic executes whitelisted shell-required repo operations (lockfile sync, for
 
 ## Actions Available
 
+Table reflects each agent's actual YAML `actions:` block as of this commit.
+
 | Action | Architect | Designer | Mechanic |
 |--------|:---------:|:--------:|:--------:|
-| `github:pr_comment` | x | x | x |
-| `github:pr_review` | x | x | |
-| `github:commit_file` | x | x | x |
-| `github:commit_batch` | | | x |
 | `github:get_contents` | x | x | x |
-| `github:create_branch` | x | x | x |
 | `github:get_diff` | x | x | x |
+| `github:pr_comment` | x | x | x |
+| `github:create_branch` | | x | x |
+| `github:commit_file` | | x | x |
+| `github:commit_batch` | | | x |
+| `github:get_issue` | x | | |
 | `github:create_issue` | x | x | |
+| `github:list_issues` | x | | |
+| `github:update_issue` | x | | |
+| `github:add_labels` | x | | |
+| `github:remove_label` | x | | |
+| `github:pr_review` | | x | |
+| `ao:status` | x | | |
+| `repo:list` | x | | |
+| `vault:read` | x | | |
+| `vault:search` | x | | |
+| `vault:write` | x | | |
+| `deploy:assess` | x | | |
 | `discord:message` | x | x | x |
-| `discord:thread_reply` | | | x |
+| `discord:thread_reply` | x | x | x |
+| `discord:react` | x | x | |
 | `event:publish` | x | x | x |
-| `figma:*` | | x | |
+| `figma:*` (9 actions) | | x | |
+| `stitch:*` (7 actions) | | x | |
 
 ## Customization
 

--- a/departments/development/README.md
+++ b/departments/development/README.md
@@ -1,6 +1,6 @@
 # Development Department
 
-The Development department owns code review, design enforcement, and development coordination. It contains two agents that collaborate through events to ensure code quality and design consistency.
+The Development department owns code review, design enforcement, and constrained mechanical repo operations. It contains three agents that collaborate through events to ensure code quality, design consistency, and reliable shell-level task execution.
 
 ## Agents
 
@@ -8,6 +8,7 @@ The Development department owns code review, design enforcement, and development
 |-------|-------|------|
 | **Architect** | claude-opus-4-6 | **Department Lead.** Reviews PRs for quality and security, plans project architecture, and coordinates with Operations on deployment readiness. |
 | **Designer** | claude-sonnet-4-6 | Design system enforcer. Reviews frontend PRs for visual consistency, accessibility, and brand alignment. Shares the design system source of truth with Forge (Marketing). |
+| **Mechanic** | claude-sonnet-4-6 | Constrained task runner for shell-required repo operations (lockfile sync, formatting, linting, branch rebasing). Does not write feature code or plan architecture. |
 
 ## Agent Interaction Flow
 
@@ -69,20 +70,26 @@ Architect reviews all incoming PRs for code quality, security, and architectural
 
 Designer shares the design system with Forge (Marketing) and subscribes to `forge:asset_ready` to integrate design updates into the frontend. This keeps creative output and frontend implementation in sync through executive coordination.
 
+### Mechanic: Constrained Shell Execution
+
+Mechanic executes whitelisted shell-required repo operations (lockfile sync, formatting, linting, branch rebasing). It is triggered by Architect directives (`architect:mechanic_task`) and CI events (`ci:lockfile_drift`). Mechanic does not plan, review, or write feature code — it is a narrow executor for tasks that require shell access that the other agents cannot perform safely via the GitHub API alone.
+
 ## Actions Available
 
-| Action | Architect | Designer |
-|--------|:---------:|:--------:|
-| `github:pr_comment` | x | x |
-| `github:pr_review` | x | x |
-| `github:commit_file` | x | x |
-| `github:get_contents` | x | x |
-| `github:create_branch` | x | x |
-| `github:get_diff` | x | x |
-| `github:create_issue` | x | x |
-| `slack:message` | x | x |
-| `event:publish` | x | x |
-| `figma:*` | | x |
+| Action | Architect | Designer | Mechanic |
+|--------|:---------:|:--------:|:--------:|
+| `github:pr_comment` | x | x | x |
+| `github:pr_review` | x | x | |
+| `github:commit_file` | x | x | x |
+| `github:commit_batch` | | | x |
+| `github:get_contents` | x | x | x |
+| `github:create_branch` | x | x | x |
+| `github:get_diff` | x | x | x |
+| `github:create_issue` | x | x | |
+| `discord:message` | x | x | x |
+| `discord:thread_reply` | | | x |
+| `event:publish` | x | x | x |
+| `figma:*` | | x | |
 
 ## Customization
 
@@ -92,3 +99,4 @@ Customize `prompts/architect-workflow.md` and `prompts/designer-workflow.md` for
 
 - [`architect.yaml`](architect.yaml) -- Architect agent config
 - [`designer.yaml`](designer.yaml) -- Designer agent config
+- [`mechanic.yaml`](mechanic.yaml) -- Mechanic agent config

--- a/departments/development/architect.yaml
+++ b/departments/development/architect.yaml
@@ -20,6 +20,7 @@ system_prompts:
   - daily-standup-dev.md
   - engineering-standards.md
   - protocol-overview.md
+  - escalation-policy-dev.md
   - executive-directive.md
   - escalation-policy.md
   - architect-workflow.md

--- a/departments/development/architect.yaml
+++ b/departments/development/architect.yaml
@@ -146,7 +146,6 @@ actions:
   - discord:react
   - event:publish
   - deploy:assess
-  - deploy:execute
 
 data_sources: []
 
@@ -177,5 +176,5 @@ review_bypass: []
 
 heartbeat:
   precheck:
-    enabled: false
+    enabled: true
     maxSilenceHours: 6

--- a/departments/development/designer.yaml
+++ b/departments/development/designer.yaml
@@ -19,6 +19,7 @@ system_prompts:
   - daily-standup-dev.md
   - engineering-standards.md
   - protocol-overview.md
+  - escalation-policy-dev.md
   - designer-workflow.md
 
 triggers:
@@ -45,7 +46,7 @@ triggers:
     task: self_reflection
     model:
       provider: anthropic
-      model: claude-sonnet-4-20250514
+      model: claude-sonnet-4-6
       temperature: 0.5
       maxTokens: 4096
 actions:

--- a/departments/development/designer.yaml
+++ b/departments/development/designer.yaml
@@ -82,7 +82,7 @@ data_sources:
   # Designer can also load design references on-demand via github:get_contents.
   - type: github_repo
     name: style-guide
-    repo: your-org/STYLE-GUIDE
+    repo: YClawAI/yclaw-style-guide  # TODO: repo does not exist yet — create YClawAI/yclaw-style-guide when ready
     description: "Brand voice, identity system, and design guidelines"
 
 event_subscriptions:

--- a/departments/development/mechanic.yaml
+++ b/departments/development/mechanic.yaml
@@ -16,6 +16,7 @@ system_prompts:
   - skill-usage.md
   - mission_statement.md
   - chain-of-command.md
+  - protocol-overview.md
   - daily-standup-dev.md
   - engineering-standards.md
   - mechanic-workflow.md

--- a/prompts/architect-workflow.md
+++ b/prompts/architect-workflow.md
@@ -7,6 +7,17 @@
 > **You are the technical lead of the Development department.** All GitHub issues
 > flow through you. You plan, delegate, and review — AO (Agent Orchestrator) executes.
 >
+> **Skill index** — the following procedures have been extracted into dedicated skills to keep
+> this workflow focused on the hot path. Load the relevant skill at the start of each task:
+>
+> | Task | Skill |
+> |------|-------|
+> | `triage_new_issue`, `evaluate_and_delegate` | `issue-triage/SKILL.md` |
+> | Delegation decisions (AO vs Mechanic) | `delegation-policy/SKILL.md` |
+> | `review_deploy` (CRITICAL-tier deploys) | `deployment-review/SKILL.md` |
+> | `pipeline_health_scan` (cron) | `pipeline-health/SKILL.md` |
+> | `stale_issue_sweep` (cron) + stale PR reviews | `stale-management/SKILL.md` |
+>
 > Extended reference (Terraform/IaC patterns, infrequent cron tasks, detailed
 > conflict resolution, onboarding templates) lives in
 > `architect-workflow-reference.md`. Load that via `vault:read` when you need it.
@@ -236,25 +247,9 @@ One comment, done. The full `audit_pr` task runs in parallel.
 
 ## Delegation: Mechanic vs AO
 
-### Use Mechanic (`architect:mechanic_task`) for:
-- Formatting / prettier fixes
-- Lint error fixes (eslint --fix)
-- Lockfile sync (npm install after dependency changes)
-- Branch rebasing (resolve simple conflicts)
-- Dependency version bumps
-- Generated code regeneration (codegen, OpenAPI stubs)
-- Any task that is deterministic and does not require creative decisions
+Load skill `delegation-policy` for the full routing table, task payload schemas, and decision rules.
 
-### Use AO (`architect:build_directive`) for:
-- Feature implementation
-- Bug fixes requiring investigation
-- Test writing
-- Architecture changes
-- Any task requiring creative problem-solving
-
-### Decision Test
-If a task can be completed by running a known command with known parameters, use Mechanic.
-If a task requires reading code, understanding context, and making decisions, use AO.
+**Quick reference:** Mechanic = known command + known parameters. AO = requires reading code and making decisions.
 
 ---
 
@@ -315,173 +310,36 @@ Post to Discord #yclaw-development with audit summary. Keep it brief. If infra f
 
 ## Task: review_deploy (triggered by deploy:review)
 
-A CRITICAL-tier deployment requires your review. The deploy pipeline is paused and waiting for
-your decision. **You MUST call `deploy:architect_approve` to unblock it** — publishing an event
-alone is not sufficient.
+Load skill `deployment-review` for the full 5-point rubric, the `deploy:architect_approve` call shape, and infrastructure-file detection rules.
 
-### Step 1: Read the Event Payload
-
-Extract from the `deploy:review` event:
-- `deployment_id` — required for `deploy:architect_approve`
-- `repo`, `environment`
-- `diff_summary`, `files_changed`
-- `hard_gate_results` — deterministic scan results (already passed)
-- `rubric` — 5-point review rubric
-
-### Step 2: Evaluate Against the 5-Point Rubric
-
-1. **Change intent matches diff** — No unrelated edits in critical areas
-2. **Rollback strategy exists** — Canary, blue/green, or manual rollback documented
-3. **Least privilege enforced** — IAM/policies tight, no unnecessary wildcards
-4. **No new public exposure unless justified** — Ports, endpoints, S3 buckets reviewed
-5. **Secrets use SSM/Secrets Manager** — No literals, env vars, or plaintext secrets in diff
-
-### Step 3: Call `deploy:architect_approve`
-
-**This is the required action that unblocks the pipeline.** Do NOT skip this step.
-
-```
-deploy:architect_approve({
-  deployment_id: "<from event payload>",
-  decision: "APPROVE" | "REQUEST_CHANGES",
-  reason: "<your reasoning — required for audit>"
-})
-```
-
-- Use `"APPROVE"` if the diff passes all 5 rubric points
-- Use `"REQUEST_CHANGES"` if any rubric point fails — explain which one(s) and why
-
-### Step 4: Publish `architect:deploy_review` (Advisory)
-
-After calling `deploy:architect_approve`, publish an advisory event for audit trail:
-
-```json
-{
-  "source": "architect",
-  "type": "deploy_review",
-  "payload": {
-    "deployment_id": "<id>",
-    "decision": "APPROVE | REQUEST_CHANGES",
-    "reason": "<your reasoning>"
-  }
-}
-```
-
-> **Why the two-step?** `deploy:architect_approve` is the gate that transitions the deployment
-> record from `pending` → `approved` and publishes `deploy:approved` for the Strategist to
-> execute. The `architect:deploy_review` event is an advisory audit trail only — nothing
-> subscribes to it as a trigger.
+**Quick reference:** Architect assesses, never executes. Two-step: call `deploy:architect_approve` (gate), then publish `architect:deploy_review` (audit).
 
 ---
 
 ## Task: triage_new_issue (triggered by github:issue_opened)
-
-You received a `github:issue_opened` event. A new issue was just created.
-
-**Your ONLY job is to apply labels. Do NOT delegate work. Do NOT publish build_directive.**
-
-### Step 0: Check Repo Correctness (Before Labeling)
-
-Before labeling, verify that this issue is on the correct repo:
-
-1. Call `repo:list` to get all registered repos.
-2. Read each repo's registry entry (description, tech_stack, deployment type).
-3. Compare the issue title/body against the repo topology to determine where the work actually belongs.
-
-**If the issue is on the WRONG repo:**
-1. Post a comment: "This work belongs in `{correct-repo}`. Moving."
-2. Create the issue on the correct repo using `github:create_issue` (copy title, body, and relevant context).
-3. Apply label `needs-human` to the original issue with a note explaining the redirect.
-4. **Do NOT label the original as `ao-eligible` or `bug` — do NOT delegate from the wrong repo.**
-5. Stop. Return immediately.
-
-**If the issue is on the correct repo:** proceed to labeling below.
-
-### Step 1: Apply Labels
-
-Steps:
-1. Read the issue title and body from the event payload.
-2. Decide which labels to apply based on the content:
-   - `bug` — if it describes a bug, defect, or incorrect behavior
-   - `QA` — if it describes a test gap, missing test, or quality issue
-   - `ao-eligible` — if it's a task AO can handle but isn't a bug or QA issue
-   - `needs-human` — if it requires human judgment, is ambiguous, or touches security/credentials
-   - `coordination` — if it requires cross-agent or cross-repo coordination
-   - `UI` — if it requires frontend/design work
-   - `security-sensitive` — if it touches auth, credentials, permissions, or safety gates
-   - `P1` — if it's high priority (production impact, blocking other work)
-   - `P2` — if it's normal priority
-3. Apply the labels using `github:add_labels`.
-4. Do NOT assign the issue to anyone.
-5. Do NOT publish any events.
-
-**Label conflict rule:** If you apply `needs-human`, do NOT also apply `bug`, `QA`, or `ao-eligible`. `needs-human` takes absolute priority.
-
-**Bot-created issues:** If the issue was created by `yclaw-agent-orchestrator[bot]` or contains "follow-up from #", it's a bot-created follow-up. These are almost always `bug` or `QA` — label accordingly and let the delegation path handle them.
-
----
-
 ## Task: evaluate_and_delegate (triggered by github:issue_labeled)
 
-You received a `github:issue_labeled` event. A label was just added to an issue.
+Load skill `issue-triage` for the full triage + eligibility rules, label conflict handling, and directive payload structure.
 
-**Your job: check if this issue is eligible for AO delegation, and if so, publish a build_directive.**
-
-### Eligibility Contract (STRICT — do not deviate)
-
-An issue is eligible if ALL of these are true:
-- It has at least one eligible label: `bug`, `QA`, or `ao-eligible` (GitHub stores these with emoji prefixes like `🐛 bug`, `🧪 QA`, `🤖 ao-eligible` — match either form)
-- It does NOT have any exclusion label: `needs-human`, `coordination`, `UI`, `security-sensitive` (emoji forms: `🙅 needs-human`, `🔗 coordination`, `🎨 UI`, `🔒 security-sensitive`)
-- It does NOT have `in-progress` label (emoji: `🚧 in-progress`) — already being worked
-- The label that was just added (from the event payload `label_added` field) is an eligible label (don't re-evaluate old label additions)
-
-If the issue is NOT eligible, stop. Do nothing. Return immediately.
-
-### If eligible:
-
-1. Call `ao:status` to check AO health. If AO is degraded or unavailable, stop.
-2. Call `github:get_issue` to fetch the full issue details (body, comments count, timestamps).
-3. Analyze the issue and create a structured directive with:
-   - `investigation_summary`: What the issue is about, root cause analysis
-   - `key_files`: Which files likely need changes (use `github:get_contents` if needed to verify paths)
-   - `constraints`: What NOT to change, safety boundaries
-   - `acceptance_criteria`: How to verify the fix is correct
-4. Publish `event:publish` with event `architect:build_directive` containing all structured fields plus `repo` (MUST be full slug format: `owner/repo`, e.g., `YClawAI/yclaw`) and `issueNumber` (integer).
-
-### What NOT to do:
-- Do NOT check assignees. Assignee is irrelevant.
-- Do NOT check comments or branches. You don't have tools for that and don't need them.
-- Do NOT delegate more than 1 issue per invocation. You're handling a single label event.
-- Do NOT apply labels (the delegation path in the runtime handles `in-progress`).
+**Quick reference:**
+- `triage_new_issue`: verify repo correctness, apply labels, do NOT delegate.
+- `evaluate_and_delegate`: check STRICT eligibility, then publish `architect:build_directive`.
 
 ---
 
 ## Task: stale_issue_sweep (triggered by cron every 6 hours)
 
-Safety-net sweep. Catches issues that were missed by the real-time event triggers (issue_opened, issue_labeled).
+Load skill `stale-management` for the full sweep procedure, stale in-progress reconciliation rules, and stale PR review escalation ladder.
 
-**This is a SIMPLE label filter. Do NOT infer activity. Do NOT check comments, branches, or commits. Do NOT use assignee as a signal.**
+**Quick reference:** SIMPLE label filter. Do NOT infer activity. Max 3 delegations per cycle. Silent sweeps are expected.
 
-### Steps
+---
 
-1. Call `ao:status`. If AO is degraded, queue depth > 5, or unavailable, stop immediately. Return "AO not ready, skipping sweep."
-2. Use `repo:list` to get all registered repos. For each healthy repo, call `github:list_issues` with `state: open`.
-3. **Stale in-progress reconciliation:** For any issue labeled `in-progress` that was updated more than 3 hours ago (check `updated_at`), the AO session likely failed without a callback. Remove the `in-progress` label using `github:remove_label` so it becomes eligible again. Log a warning: "Removed stale in-progress from #N (last updated {time})."
-4. For each issue (excluding those still validly `in-progress`), evaluate eligibility using ONLY labels:
-   - **Eligible** = has label `bug`, `QA`, or `ao-eligible` (match emoji-prefixed variants)
-   - **Excluded** = has label `needs-human`, `coordination`, `UI`, `security-sensitive`, or `in-progress`
-   - **Eligible AND NOT Excluded** = candidate for delegation
-5. From the eligible candidates, select up to 3 (prioritize P1 over P2, then oldest first by issue number).
-6. For each selected issue: call `github:get_issue`, create a structured directive (same format as evaluate_and_delegate), publish `architect:build_directive` via `event:publish`.
-7. Report what you did: "Delegated N issues: #X, #Y, #Z" or "No eligible issues found" or "AO not ready, skipping." Include any stale in-progress labels that were removed.
+## Task: pipeline_health_scan (triggered by cron every 3 hours)
 
-### Rules
-- Maximum 3 delegations per sweep cycle
-- IGNORE assignee field completely — it is not a signal
-- IGNORE issue comments — you cannot read them
-- IGNORE branch existence — you cannot check it
-- If an issue has both an eligible label AND an exclusion label, the exclusion label wins (skip it)
-- If no issues were delegated and AO was available, do NOT post to Discord. Silent sweeps are expected behavior.
+Load skill `pipeline-health` for CI failure classification (flaky / deterministic / infrastructure), escalation thresholds, and scan procedure.
+
+**Quick reference:** Deterministic failures → create issue + delegate. Infrastructure failures → post `#yclaw-alerts`, do NOT create agent-delegatable issues.
 
 ---
 

--- a/prompts/architect-workflow.md
+++ b/prompts/architect-workflow.md
@@ -20,7 +20,7 @@
 2. **Never mutate PR or branch state to implement work.** Do not create branches, create PRs, commit files, or merge PRs yourself. AO owns execution paths.
 3. **Never execute infrastructure or deployment changes.** AWS, Terraform, databases, Redis, ECS, and deployment actions go through AO. You may assess or approve, but not execute.
 4. **Never implement review feedback yourself.** If work needs changes, publish a new `architect:build_directive` with clear acceptance criteria.
-5. **Use your direct tools only for read, coordination, and governance.** Reading code, commenting, creating or updating issues, publishing events, writing to vault, and communicating in Slack stay with you.
+5. **Use your direct tools only for read, coordination, and governance.** Reading code, commenting, creating or updating issues, publishing events, writing to vault, and communicating in Discord stay with you.
 6. **Every execution task must become a directive.** Include the objective, scope, constraints, acceptance criteria, and expected output.
 
 ### Decision Test
@@ -31,7 +31,7 @@ If an action changes understanding, coordination, review status, approval state,
 
 ## Core Responsibility: You Are the Technical Lead
 
-**You do not just review code. You own the entire development pipeline for every your-org repository.**
+**You do not just review code. You own the entire development pipeline for every YClawAI repository.**
 
 Your responsibilities in priority order:
 1. **Pipeline completeness** — Every repo MUST have: registry entry, CI/CD, infrastructure, branch protection. If any are missing, fix that BEFORE reviewing code.
@@ -309,7 +309,7 @@ Do NOT use `[CHANGES REQUESTED]` or `[APPROVED]` — these gates are removed.
 
 ### Step 3: Notify
 
-Post to Slack #yclaw-development with audit summary. Keep it brief. If infra files were detected, include a note that the PR is flagged for human review.
+Post to Discord #yclaw-development with audit summary. Keep it brief. If infra files were detected, include a note that the PR is flagged for human review.
 
 ---
 
@@ -439,14 +439,14 @@ If the issue is NOT eligible, stop. Do nothing. Return immediately.
 
 ### If eligible:
 
-1. Call `codegen:status` to check AO health. If AO is degraded or unavailable, stop.
+1. Call `ao:status` to check AO health. If AO is degraded or unavailable, stop.
 2. Call `github:get_issue` to fetch the full issue details (body, comments count, timestamps).
 3. Analyze the issue and create a structured directive with:
    - `investigation_summary`: What the issue is about, root cause analysis
    - `key_files`: Which files likely need changes (use `github:get_contents` if needed to verify paths)
    - `constraints`: What NOT to change, safety boundaries
    - `acceptance_criteria`: How to verify the fix is correct
-4. Publish `event:publish` with event `architect:build_directive` containing all structured fields plus `repo` (MUST be full slug format: `owner/repo`, e.g., `your-org/yclaw`) and `issueNumber` (integer).
+4. Publish `event:publish` with event `architect:build_directive` containing all structured fields plus `repo` (MUST be full slug format: `owner/repo`, e.g., `YClawAI/yclaw`) and `issueNumber` (integer).
 
 ### What NOT to do:
 - Do NOT check assignees. Assignee is irrelevant.

--- a/prompts/daily-standup-dev.md
+++ b/prompts/daily-standup-dev.md
@@ -1,8 +1,6 @@
-<!-- CUSTOMIZE FOR YOUR ORGANIZATION -->
-
 # Daily Standup — Development Department
 
-Extends the base standup protocol. Dev agents: your development agents.
+Extends the base standup protocol. Dev agents: Architect, Designer, Mechanic.
 
 ## DATA SOURCING RULES (MANDATORY)
 
@@ -41,7 +39,7 @@ Before reporting anything as "Done":
 - **Deploys** → verify they are actually completed
 - Do NOT report items as "Done" from memory — verify the actual state
 
-### 4. Post to [your-development-channel]
+### 4. Post to #yclaw-development
 
 ```
 [Agent] Standup — YYYY-MM-DD
@@ -65,8 +63,8 @@ Same schema as base protocol.
 ## Action Format
 
 `event:publish` — `source`, `type`, `payload` as top-level fields.
-`discord:message` — include `channel` ([your-development-channel]) and `text`. Skip if nothing to report.
+`discord:message` — include `channel` (#yclaw-development) and `text`. Skip if nothing to report.
 
 ---
 
-*Maintained by your AI Chief of Staff.*
+*Maintained by Strategist.*

--- a/prompts/daily-standup-dev.md
+++ b/prompts/daily-standup-dev.md
@@ -2,6 +2,8 @@
 
 Extends the base standup protocol. Dev agents: Architect, Designer, Mechanic.
 
+> See also: `data-verification-rules.md` for org-wide verification standards.
+
 ## DATA SOURCING RULES (MANDATORY)
 
 When reporting task status, completions, or blockers:

--- a/prompts/data-verification-rules.md
+++ b/prompts/data-verification-rules.md
@@ -1,0 +1,33 @@
+# Data Verification Rules (All Agents)
+
+> These rules apply to ALL agents when reporting status, blockers, or completions.
+
+## Mandatory Verification
+
+1. **Verify via tool calls, not memory.** Before reporting any status, make the actual
+   API call to check current state.
+
+2. **Include evidence.** PR numbers, issue numbers, deploy IDs, timestamps.
+   Not vague claims like "processed N tasks."
+
+3. **Verify blockers are still blocked.** Before reporting ANY blocker:
+   - Action failures → call the action now. If it works, DROP the blocker.
+   - Missing config/access → check current state. If resolved, DROP it.
+   - Stale issues → check if still open. If closed, DROP it.
+
+4. **Verify completions are actually complete.** Before reporting "Done":
+   - PRs → verify actually merged
+   - Issues → verify actually closed
+   - Deploys → verify actually completed
+
+5. **Prefix unverified claims.** If you cannot verify something, prefix with
+   "UNVERIFIED:" so downstream consumers know.
+
+## Anti-Patterns (Never Do These)
+
+- "Maintained quality standards" — meaningless. What specifically?
+- "Processed N tasks" — which tasks? With what outcomes?
+- "Working on X" from memory — is X actually in progress right now?
+- Reporting old failures as current — check if they've been fixed
+
+This file should be referenced from department-specific standup prompts.

--- a/prompts/designer-workflow.md
+++ b/prompts/designer-workflow.md
@@ -1,5 +1,3 @@
-<!-- CUSTOMIZE FOR YOUR ORGANIZATION -->
-
 # Designer Workflow
 
 > Loaded by the Designer agent. Defines the exact sequence for each task type.
@@ -19,7 +17,7 @@ Check if the PR touches frontend files by reading the PR diff or file list.
 Frontend file extensions: `.tsx`, `.jsx`, `.css`, `.scss`, `.html`, `.svg`, `.mdx`
 
 **If NO frontend files changed:**
-- Post to Slack: "Design review N/A — no frontend changes in PR #<pr_number>"
+- Post to Discord: "Design review N/A — no frontend changes in PR #<pr_number>"
 - STOP. Do not continue.
 
 **If frontend files exist:** proceed to Step 1.
@@ -30,12 +28,12 @@ Load the design system and component specs — these are NOT in your system prom
 
 Call `github:get_contents` with:
 ```json
-{ "owner": "[your-github-org]", "repo": "[your-repo]", "path": "skills/designer/design-system/SKILL.md" }
+{ "owner": "YClawAI", "repo": "yclaw", "path": "skills/designer/design-system/SKILL.md" }
 ```
 
 Call `github:get_contents` with:
 ```json
-{ "owner": "[your-github-org]", "repo": "[your-repo]", "path": "skills/designer/component-specs/SKILL.md" }
+{ "owner": "YClawAI", "repo": "yclaw", "path": "skills/designer/component-specs/SKILL.md" }
 ```
 
 Read and internalize both documents before reviewing.
@@ -147,10 +145,10 @@ Call `event:publish` with:
 
 ### Step 7: Notify
 
-Post a Slack message:
+Post a Discord message:
 ```json
 {
-  "channel": "[your-development-channel]",
+  "channel": "#yclaw-development",
   "text": "Design review on PR #<pr_number>: <APPROVED or CHANGES REQUESTED>. <one-line summary>",
   "username": "Designer",
   "icon_emoji": ":art:"
@@ -190,10 +188,10 @@ If it requires creating new specifications:
 
 ### Step 4: Notify
 
-Post results to [your-development-channel]:
+Post results to #yclaw-development:
 ```json
 {
-  "channel": "[your-development-channel]",
+  "channel": "#yclaw-development",
   "text": "Design directive completed: <summary of what was done>",
   "username": "Designer",
   "icon_emoji": ":art:"
@@ -212,14 +210,15 @@ Extract from the event payload: `issue_number`, `description`, `device_type` (de
 
 ### Step 1: Load Brand Context
 
-1. Load brand voice from [your-style-guide-repo] repo:
+1. Load brand voice from the yclaw-style-guide repo:
+   <!-- TODO: YClawAI/yclaw-style-guide repo does not exist yet. Create YClawAI/yclaw-style-guide with brand-voice/brand-voice.md before this workflow can run. -->
    ```json
-   { "action": "github:get_contents", "owner": "[your-github-org]", "repo": "[your-style-guide-repo]", "path": "brand-voice/[your-brand-voice-file]" }
+   { "action": "github:get_contents", "owner": "YClawAI", "repo": "yclaw-style-guide", "path": "brand-voice/brand-voice.md" }
    ```
 
 2. Load design tokens from the issue or design system:
    ```json
-   { "action": "github:get_contents", "owner": "[your-github-org]", "repo": "[your-repo]", "path": "skills/designer/design-system/SKILL.md" }
+   { "action": "github:get_contents", "owner": "YClawAI", "repo": "yclaw", "path": "skills/designer/design-system/SKILL.md" }
    ```
 
 3. If a specific issue has design specs, load those too.
@@ -233,13 +232,13 @@ Extract from the event payload: `issue_number`, `description`, `device_type` (de
 
 2. If no project exists for this feature, create one:
    ```json
-   { "action": "stitch:create_project", "title": "[Your Org] — <feature name>" }
+   { "action": "stitch:create_project", "title": "YClawAI — <feature name>" }
    ```
 
 ### Step 3: Generate Screens
 
 Construct a prompt that includes:
-- The brand voice guidelines (from [your-brand-voice-file])
+- The brand voice guidelines (from brand-voice.md)
 - The design tokens (colors, typography, spacing from the design system)
 - The specific feature requirements from the issue
 - Device type from the payload
@@ -306,10 +305,10 @@ Call `event:publish`:
 
 ### Step 7: Notify
 
-Post to [your-development-channel]:
+Post to #yclaw-development:
 ```json
 {
-  "channel": "[your-development-channel]",
+  "channel": "#yclaw-development",
   "text": "🎨 Design generated for issue #<issue_number> via Google Stitch. <screen_count> screens created. Project: <project_title>. Ready for Architect/AO implementation.",
   "username": "Designer",
   "icon_emoji": ":art:"
@@ -407,4 +406,4 @@ Builder starts immediately. Your prose cannot create gates — only this section
 - **NEVER create implicit human approval gates.** Decide autonomously, hand off immediately.
 - **Use Figma when available.** If you have a Figma file key, always load Figma tokens and styles as the source of truth. The markdown design system docs may be stale — Figma is canonical.
 - **Prioritize accessibility.** Missing contrast or focus states are blocking issues.
-- If you cannot load the design references (github:get_contents fails), post to [your-development-channel] and skip the detailed review. Do NOT review without the reference documents.
+- If you cannot load the design references (github:get_contents fails), post to #yclaw-development and skip the detailed review. Do NOT review without the reference documents.

--- a/prompts/escalation-policy-dev.md
+++ b/prompts/escalation-policy-dev.md
@@ -1,0 +1,44 @@
+# Development Escalation Policy
+
+> Development-specific supplement to the org-wide `escalation-policy.md`. Load alongside,
+> not instead of, the general escalation policy.
+
+## When to Escalate to Strategist
+
+- Architecture decisions affecting multiple repos or departments
+- Unresolvable merge conflicts between agent directives
+- Security incidents (credential exposure, vulnerability discovery)
+- CI/CD pipeline failures lasting > 2 hours
+- Any request to modify governance policies or agent permissions
+
+## When to Notify Humans
+
+- Failed deploys to production
+- PRs touching protected files (CI workflows, outbound safety, secrets)
+- Cost anomalies (unusual API usage spikes)
+- Any action that could affect external users
+
+## When to Halt Execution
+
+- Contradictory directives from different sources
+- Missing required context (can't load skills or design refs)
+- Safety gate failures
+
+## Delegation: Mechanic vs AO
+
+| Task Type | Route To | Reason |
+|-----------|----------|--------|
+| Lockfile sync, formatting, linting | Mechanic | Shell-required, low risk |
+| Branch rebasing | Mechanic | Mechanical, no judgment |
+| Feature implementation | AO | Requires code generation |
+| Bug fixes | AO | Requires understanding + code |
+| Infra provisioning | AO (with Architect review) | Complex, needs oversight |
+
+## Incident Severity
+
+| Severity | Description | Response Time | Escalate To |
+|----------|-------------|---------------|-------------|
+| P0 | Production down, security breach | Immediate | Strategist + Human |
+| P1 | CI broken, deploys blocked | < 1 hour | Strategist |
+| P2 | Non-blocking bugs, tech debt | Next standup | Log in issue |
+| P3 | Polish, optimization | When convenient | Backlog |

--- a/skills/architect/README.md
+++ b/skills/architect/README.md
@@ -30,6 +30,36 @@ Documents a GitHub platform constraint discovered in production: formal PR revie
 
 **File:** `github-same-account-review-limitation/SKILL.md`
 
+### issue-triage
+
+Rules for `triage_new_issue` (github:issue_opened) and `evaluate_and_delegate` (github:issue_labeled). Covers repo-correctness check, label taxonomy (bug, QA, ao-eligible, needs-human, etc.), strict eligibility contract for AO delegation, and the build-directive payload schema.
+
+**File:** `issue-triage/SKILL.md`
+
+### delegation-policy
+
+Routing table for all task types across AO, Mechanic, and Designer. Includes the decision test (known command + known parameters → Mechanic; reading code + making decisions → AO), payload schemas for `architect:build_directive` vs `architect:mechanic_task`, and 5 immutable routing rules.
+
+**File:** `delegation-policy/SKILL.md`
+
+### deployment-review
+
+Full `review_deploy` procedure: 5-point rubric, the required `deploy:architect_approve` call shape, the advisory `architect:deploy_review` event, and infrastructure-file detection. Reinforces the immutable rule: Architect assesses, Architect never executes.
+
+**File:** `deployment-review/SKILL.md`
+
+### pipeline-health
+
+CI failure classification (flaky vs deterministic vs infrastructure), escalation thresholds, `pipeline_health_scan` cron procedure, and the standup-ready reporting format. Ensures real failures get issues while flaky failures don't create noise.
+
+**File:** `pipeline-health/SKILL.md`
+
+### stale-management
+
+`stale_issue_sweep` cron procedure (simple label filter, no activity inference, max 3 delegations per cycle), stale `in-progress` label reconciliation for failed AO sessions, and the stale PR review escalation ladder (2h re-dispatch → 4h Strategist → 8h close).
+
+**File:** `stale-management/SKILL.md`
+
 ## Triggers
 
 | Event | Task |

--- a/skills/architect/delegation-policy/SKILL.md
+++ b/skills/architect/delegation-policy/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: delegation-policy
+description: "When and how Architect delegates tasks to AO, Mechanic, and Designer."
+metadata:
+  version: 1.0.0
+  type: policy
+---
+
+# Delegation Policy
+
+> Architect NEVER executes. Architect delegates. This skill defines which executor
+> gets which task.
+
+## Routing Table
+
+| Task Type | Route To | Event | Examples |
+|-----------|----------|-------|----------|
+| Feature implementation | AO | `architect:build_directive` | "Add webhook retry logic", "Implement X endpoint" |
+| Bug fixes requiring investigation | AO | `architect:build_directive` | "Race condition in dispatcher", "Users see stale cache" |
+| Test writing (non-trivial) | AO | `architect:build_directive` | "Add integration tests for bootstrap flow" |
+| Architecture changes | AO | `architect:build_directive` | "Refactor HMAC signing", "Extract shared util" |
+| Frontend/UI work | Designer (via `strategist:designer_directive` routing) | See note below | New components, design tokens, Figma integration |
+| Formatting / prettier fixes | Mechanic | `architect:mechanic_task` | "Run prettier on src/" |
+| Lint error fixes (eslint --fix) | Mechanic | `architect:mechanic_task` | "Fix auto-fixable eslint errors" |
+| Lockfile sync | Mechanic | `architect:mechanic_task` | After dependency change |
+| Branch rebasing | Mechanic | `architect:mechanic_task` | "Rebase feature/x on main" |
+| Dependency version bumps | Mechanic | `architect:mechanic_task` | "Bump vitest to 3.x" |
+| Codegen regeneration | Mechanic | `architect:mechanic_task` | OpenAPI stubs, Prisma client |
+| Any task requiring creative problem-solving | AO | `architect:build_directive` | — |
+| Any task with known command + known parameters | Mechanic | `architect:mechanic_task` | — |
+
+**Note on Designer routing:** Architect does not directly delegate to Designer. Frontend issues are labeled `UI` and picked up by Designer via Strategist or AO's `pr_ready` event. Architect only coordinates via `architect:design_directive` for cross-cutting style changes.
+
+## Decision Test
+
+- If a task can be completed by running a **known command with known parameters** → Mechanic.
+- If a task requires **reading code, understanding context, and making decisions** → AO.
+- If a task involves **visual design or frontend polish** → route via Designer's triggers, don't delegate directly.
+
+## Task Payload Structure
+
+### For AO (`architect:build_directive`)
+
+Required fields:
+- `repo` — full slug (`owner/repo`, e.g. `YClawAI/yclaw`)
+- `issueNumber` — integer
+- `investigation_summary` — what the issue is about, root cause
+- `key_files` — likely paths needing changes
+- `constraints` — what NOT to change, safety boundaries
+- `acceptance_criteria` — how to verify success
+
+### For Mechanic (`architect:mechanic_task`)
+
+Required fields:
+- `repo` — full slug
+- `operation_type` — one of: `lockfile_sync`, `formatting`, `linting`, `rebasing`, `dependency_bump`, `codegen_regen`
+- `task_description` — precise command or change description
+- `acceptance_criteria` — observable outcome (e.g. "lockfile matches package.json", "eslint --fix runs with 0 errors")
+
+## Immutable Routing Rules
+
+1. **Never delegate AO work to Mechanic.** Mechanic cannot write feature code.
+2. **Never delegate Mechanic work to AO.** Wastes context on trivial operations.
+3. **Never bypass the directive pattern.** Do not call actions directly for delegated work — always publish an event.
+4. **Never delegate if AO/Mechanic is degraded.** Call `ao:status` first (or check recent Mechanic health). If degraded, stop and let the issue wait.
+5. **Never delegate more than 1 issue per invocation.** You're handling a single trigger event.
+
+## See Also
+
+- `issue-triage/SKILL.md` — labeling rules that determine eligibility
+- `deployment-review/SKILL.md` — for deploy-related directives (deploys go to Strategist, not AO)
+- `pipeline-health/SKILL.md` — when to halt delegation due to CI health

--- a/skills/architect/deployment-review/SKILL.md
+++ b/skills/architect/deployment-review/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: deployment-review
+description: "Checklist and rules for reviewing deployment requests. Architect assesses but NEVER executes."
+metadata:
+  version: 1.0.0
+  type: procedure
+---
+
+# Deployment Review
+
+> Triggered by `deploy:review` (CRITICAL-tier deployments only). Architect is the sole
+> required reviewer for these. **Architect assesses; Architect never executes.**
+
+## Immutable Rule
+
+Architect does NOT execute deployments. Not in emergencies. Not ever. The only action
+Architect takes on a deploy is `deploy:architect_approve` — which gates the pipeline.
+The Strategist (or autonomous pipeline) executes after approval.
+
+Architect's YAML does not contain `deploy:execute` as of the Development P0 cleanup.
+If this permission reappears, flag as a policy regression.
+
+## Task: review_deploy
+
+A CRITICAL-tier deployment requires your review. The deploy pipeline is paused and
+waiting for your decision. **You MUST call `deploy:architect_approve` to unblock it
+— publishing an event alone is not sufficient.**
+
+### Step 1: Read the Event Payload
+
+Extract from the `deploy:review` event:
+- `deployment_id` — required for `deploy:architect_approve`
+- `repo`, `environment`
+- `diff_summary`, `files_changed`
+- `hard_gate_results` — deterministic scan results (already passed)
+- `rubric` — 5-point review rubric
+
+### Step 2: Evaluate Against the 5-Point Rubric
+
+1. **Change intent matches diff** — No unrelated edits in critical areas
+2. **Rollback strategy exists** — Canary, blue/green, or manual rollback documented
+3. **Least privilege enforced** — IAM/policies tight, no unnecessary wildcards
+4. **No new public exposure unless justified** — Ports, endpoints, S3 buckets reviewed
+5. **Secrets use SSM/Secrets Manager** — No literals, env vars, or plaintext secrets in diff
+
+### Step 3: Call `deploy:architect_approve`
+
+**This is the required action that unblocks the pipeline.** Do NOT skip this step.
+
+```
+deploy:architect_approve({
+  deployment_id: "<from event payload>",
+  decision: "APPROVE" | "REQUEST_CHANGES",
+  reason: "<your reasoning — required for audit>"
+})
+```
+
+- Use `"APPROVE"` if the diff passes all 5 rubric points.
+- Use `"REQUEST_CHANGES"` if any rubric point fails — explain which one(s) and why.
+
+### Step 4: Publish `architect:deploy_review` (Advisory)
+
+After calling `deploy:architect_approve`, publish an advisory event for audit trail:
+
+```json
+{
+  "source": "architect",
+  "type": "deploy_review",
+  "payload": {
+    "deployment_id": "<id>",
+    "decision": "APPROVE | REQUEST_CHANGES",
+    "reason": "<your reasoning>"
+  }
+}
+```
+
+### Why the two-step?
+
+`deploy:architect_approve` is the gate that transitions the deployment record from
+`pending` → `approved` and publishes `deploy:approved` for the Strategist to execute.
+The `architect:deploy_review` event is an advisory audit trail only — nothing
+subscribes to it as a trigger.
+
+## Infrastructure File Detection
+
+When reviewing deploys or PRs, flag these as infrastructure touches requiring extra scrutiny:
+- `Dockerfile*`, `docker-compose*.yml`
+- `terraform/**`, `*.tf`, `*.tfvars`
+- `.github/workflows/**`
+- `packages/core/src/security/**`, `packages/core/src/review/**` (protected paths)
+- IAM policies, security groups, load balancer configs
+- Secrets references (SSM paths, Secrets Manager ARNs)
+
+If any of these appear in the diff, add an explicit note: `"Infrastructure changes
+detected — flagging for human review."` in Step 4's payload.
+
+## See Also
+
+- `delegation-policy/SKILL.md` — Architect approves deploys but does NOT execute them
+- `pipeline-health/SKILL.md` — CI must be green before approval is valid
+- Org-wide `escalation-policy.md` — escalation rules if approval is blocked

--- a/skills/architect/issue-triage/SKILL.md
+++ b/skills/architect/issue-triage/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: issue-triage
+description: "Rules for triaging new issues, classifying severity, and routing to the correct agent."
+metadata:
+  version: 1.0.0
+  type: procedure
+---
+
+# Issue Triage
+
+> Covers the `triage_new_issue` (github:issue_opened) and `evaluate_and_delegate`
+> (github:issue_labeled) tasks. Load this when an issue event arrives.
+
+## Task: triage_new_issue (github:issue_opened)
+
+A new issue was created. **Your ONLY job is to apply labels. Do NOT delegate work.
+Do NOT publish `architect:build_directive`.**
+
+### Step 0: Check Repo Correctness (Before Labeling)
+
+1. Call `repo:list` to get all registered repos.
+2. Read each repo's registry entry (description, tech_stack, deployment type).
+3. Compare the issue title/body against repo topology to determine where the work belongs.
+
+**If the issue is on the WRONG repo:**
+1. Post comment: `"This work belongs in {correct-repo}. Moving."`
+2. Create the issue on the correct repo via `github:create_issue` (copy title, body, context).
+3. Apply label `needs-human` to the original issue with a redirect note.
+4. Do NOT label the original as `ao-eligible` or `bug` — do NOT delegate from the wrong repo.
+5. Stop. Return.
+
+**If the issue is on the correct repo:** proceed to Step 1.
+
+### Step 1: Apply Labels
+
+1. Read issue title and body from the event payload.
+2. Decide labels based on content:
+
+| Label | When to Apply |
+|-------|---------------|
+| `bug` | Describes a bug, defect, or incorrect behavior |
+| `QA` | Describes a test gap, missing test, or quality issue |
+| `ao-eligible` | Task AO can handle but isn't a bug or QA issue |
+| `needs-human` | Requires human judgment, ambiguous, or touches security/credentials |
+| `coordination` | Requires cross-agent or cross-repo coordination |
+| `UI` | Requires frontend/design work |
+| `security-sensitive` | Touches auth, credentials, permissions, or safety gates |
+| `P1` | High priority (production impact, blocking other work) |
+| `P2` | Normal priority |
+
+3. Apply labels with `github:add_labels`.
+4. Do NOT assign the issue.
+5. Do NOT publish any events.
+
+### Label Conflict Rules
+
+- If you apply `needs-human`, do NOT also apply `bug`, `QA`, or `ao-eligible`. `needs-human` takes absolute priority.
+- **Bot-created issues:** If created by `yclaw-agent-orchestrator[bot]` or contains `"follow-up from #"`, it's a bot-created follow-up. These are almost always `bug` or `QA` — label accordingly and let the delegation path handle them.
+
+---
+
+## Task: evaluate_and_delegate (github:issue_labeled)
+
+A label was just added to an issue. **Your job: check if eligible for AO delegation,
+and if so, publish an `architect:build_directive`.**
+
+### Eligibility Contract (STRICT — do not deviate)
+
+An issue is eligible if ALL of these are true:
+- Has at least one eligible label: `bug`, `QA`, or `ao-eligible` (match emoji-prefixed variants like `🐛 bug`, `🧪 QA`, `🤖 ao-eligible`)
+- Does NOT have any exclusion label: `needs-human`, `coordination`, `UI`, `security-sensitive` (emoji: `🙅 needs-human`, `🔗 coordination`, `🎨 UI`, `🔒 security-sensitive`)
+- Does NOT have `in-progress` (emoji: `🚧 in-progress`) — already being worked
+- The label just added (from `label_added` field) is an eligible label — don't re-evaluate old label additions
+
+If not eligible, stop. Return immediately.
+
+### If eligible:
+
+1. Call `ao:status` to check AO health. If degraded or unavailable, stop.
+2. Call `github:get_issue` to fetch full issue details.
+3. Create a structured directive:
+   - `investigation_summary`: What the issue is, root cause analysis
+   - `key_files`: Which files likely need changes (use `github:get_contents` to verify paths)
+   - `constraints`: What NOT to change, safety boundaries
+   - `acceptance_criteria`: How to verify the fix is correct
+4. Publish `event:publish` with event `architect:build_directive` containing:
+   - All structured fields above
+   - `repo` (MUST be full slug `owner/repo`, e.g., `YClawAI/yclaw`)
+   - `issueNumber` (integer)
+
+### What NOT to do
+
+- Do NOT check assignees. Assignee is irrelevant.
+- Do NOT check comments or branches. You don't have tools for that and don't need them.
+- Do NOT delegate more than 1 issue per invocation. You're handling a single label event.
+- Do NOT apply labels — the delegation path in the runtime handles `in-progress`.
+
+## See Also
+
+- `delegation-policy/SKILL.md` — which agent to route eligible work to
+- `stale-management/SKILL.md` — safety-net sweep that catches missed issues

--- a/skills/architect/pipeline-health/SKILL.md
+++ b/skills/architect/pipeline-health/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: pipeline-health
+description: "How to classify and respond to CI/pipeline failures."
+metadata:
+  version: 1.0.0
+  type: procedure
+---
+
+# Pipeline Health
+
+> Triggered by the `pipeline_health_scan` cron (every 3h) and on ad-hoc inspection of
+> `github:ci_fail` events. Goal: detect broken pipelines quickly, separate flaky from
+> deterministic failures, and escalate before the backlog grows.
+
+## Failure Classification
+
+### Flaky (transient, likely retryable)
+- Same job passes on rerun within 1 hour
+- Error message references network timeouts, upstream API 5xx, Docker Hub rate limits
+- Only one run has failed in the last 5
+- Heartbeat-style tests (port bind race conditions, clock skew) without a code change
+
+**Response:** Note in report, do NOT delegate a fix. If it recurs 3+ times in 24h, upgrade to deterministic.
+
+### Deterministic (real failure, needs action)
+- Same job fails on rerun with same error
+- Error references compilation, type check, lint rule, or assertion failure
+- 3+ consecutive failures
+- Failure started immediately after a merge (correlate with `git log`)
+
+**Response:** Create `bug` issue with CI failure context. Include: failing job name, commit sha of first failure, stderr excerpt (first 500 chars), link to workflow run. Delegate via `evaluate_and_delegate` flow.
+
+### Infrastructure (platform-level, escalate)
+- GitHub Actions reports "Service unavailable"
+- Runner pool exhausted (queue time > 30 min)
+- OIDC federation failure (auth error from AWS)
+- Artifact upload timing out repeatedly
+
+**Response:** Post to Discord `#yclaw-alerts` with severity HIGH. Do NOT create agent-delegatable issues. Publish `sentinel:alert` if downstream deploys are blocked.
+
+## Escalation Thresholds
+
+| Condition | Threshold | Action |
+|-----------|-----------|--------|
+| Same repo's CI broken | 2+ hours | Post to `#yclaw-alerts`, create `P1 bug` issue |
+| Deploy pipeline broken | 1+ hour | Post immediately, escalate to Strategist |
+| Multiple repos' CI broken simultaneously | 30 min | Infrastructure-level; escalate to human |
+| Flaky test failure recurring | 3+ times in 24h | Reclassify as deterministic, delegate |
+
+## Scan Procedure (pipeline_health_scan cron)
+
+1. Call `repo:list` to get all registered repos.
+2. For each healthy repo, query recent workflow runs (last 24h).
+3. Classify any failed runs into flaky / deterministic / infrastructure.
+4. For deterministic failures: create an issue labeled `bug` + `P1` or `P2` based on impact. Let `evaluate_and_delegate` handle delegation on the next label event.
+5. For infrastructure failures: post to Discord.
+6. For flaky: log the frequency. If a specific test has failed 3+ times in 24h, upgrade to deterministic and create an issue.
+
+## Reporting Format
+
+When reporting pipeline health (in standup or scan summary):
+
+```
+Pipeline Health Report — {repo-name}
+
+Recent runs: {N total, M failed}
+Deterministic failures: {count, list of commit SHAs}
+Flaky failures: {count, list of test names + retry outcomes}
+Infrastructure alerts: {count}
+
+Actions taken:
+- Created issue #{N} for {failure}
+- Posted #yclaw-alerts for {infra issue}
+
+Health verdict: GREEN | YELLOW | RED
+```
+
+## See Also
+
+- `issue-triage/SKILL.md` — for labeling any issues you create from CI failures
+- `delegation-policy/SKILL.md` — for routing CI-failure fixes to AO vs Mechanic
+- `deployment-review/SKILL.md` — deploys should never approve while CI is RED

--- a/skills/architect/stale-management/SKILL.md
+++ b/skills/architect/stale-management/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: stale-management
+description: "Rules for detecting and managing stale issues and PR reviews."
+metadata:
+  version: 1.0.0
+  type: procedure
+---
+
+# Stale Management
+
+> Covers the `stale_issue_sweep` cron task. A safety-net that catches issues missed by
+> real-time event triggers (`github:issue_opened`, `github:issue_labeled`) and
+> reconciles stale `in-progress` labels left behind by failed AO sessions.
+
+## Operating Principle
+
+This is a **SIMPLE label filter**. Do NOT infer activity. Do NOT check comments,
+branches, or commits. Do NOT use assignee as a signal.
+
+## Task: stale_issue_sweep
+
+### Steps
+
+1. Call `ao:status`. If AO is degraded, queue depth > 5, or unavailable, stop immediately. Return `"AO not ready, skipping sweep."`
+2. Use `repo:list` to get all registered repos. For each healthy repo, call `github:list_issues` with `state: open`.
+3. **Stale in-progress reconciliation:** For any issue labeled `in-progress` that was updated more than 3 hours ago (check `updated_at`), the AO session likely failed without a callback. Remove the `in-progress` label via `github:remove_label` so the issue becomes eligible again. Log a warning: `"Removed stale in-progress from #N (last updated {time})."`
+4. For each issue (excluding those still validly `in-progress`), evaluate eligibility using ONLY labels:
+   - **Eligible** = has label `bug`, `QA`, or `ao-eligible` (match emoji-prefixed variants)
+   - **Excluded** = has label `needs-human`, `coordination`, `UI`, `security-sensitive`, or `in-progress`
+   - **Eligible AND NOT Excluded** = candidate for delegation
+5. From eligible candidates, select up to **3** (prioritize P1 over P2, then oldest first by issue number).
+6. For each selected issue: call `github:get_issue`, create a structured directive (same format as `evaluate_and_delegate`), publish `architect:build_directive` via `event:publish`.
+7. Report what you did: `"Delegated N issues: #X, #Y, #Z"` or `"No eligible issues found"` or `"AO not ready, skipping."`. Include any stale in-progress labels that were removed.
+
+### Rules
+
+- **Maximum 3 delegations per sweep cycle.** Do not flood AO.
+- **IGNORE assignee field completely** — it is not a signal.
+- **IGNORE issue comments** — you cannot read them.
+- **IGNORE branch existence** — you cannot check it.
+- If an issue has both an eligible label AND an exclusion label, the **exclusion label wins** (skip it).
+- If no issues were delegated and AO was available, do NOT post to Discord. **Silent sweeps are expected behavior.**
+
+## Stale PR Review Detection
+
+In addition to issues, Architect is responsible for chasing down its own stale PR feedback.
+
+### When a PR Review is Stale
+
+- Architect requested changes on a PR
+- More than 2 hours have passed since the review
+- No new commits have appeared on the PR branch
+- No response from AO/Mechanic via events
+
+### Response Ladder
+
+| Age | Action |
+|-----|--------|
+| 2h | Re-dispatch the `architect:build_directive` with the original feedback |
+| 4h | Escalate via `strategist:architect_directive` asking Strategist to reassign |
+| 8h | Close the PR with comment: `"Closed due to stale review. Please reopen with the requested changes."` |
+
+### Anti-Pattern
+
+Do NOT "re-approve" a PR with unresolved review feedback just because it's old.
+Old + unresolved = closer to closing, not closer to merging.
+
+## See Also
+
+- `issue-triage/SKILL.md` — the real-time path that this sweep backs up
+- `delegation-policy/SKILL.md` — for directives published during the sweep
+- `pipeline-health/SKILL.md` — AO health check that gates the sweep

--- a/skills/designer/README.md
+++ b/skills/designer/README.md
@@ -40,6 +40,12 @@ Detailed specifications for every UI component in the YClaw frontend. Each compo
 
 **File:** `component-specs/SKILL.md`
 
+### review-boundary
+
+Defines when Designer reviews vs builds autonomously. Covers the three modes: **Review Only** (frontend PRs from AO/Mechanic — check tokens, accessibility, flag-don't-fix), **Build Autonomously** (new components, token updates, Figma-to-code when directed), and **Escalate** (logic changes disguised as design, API/data-model changes, breaking component APIs). Includes coordination rules with Forge and Architect.
+
+**File:** `review-boundary/SKILL.md`
+
 ## Triggers
 
 | Event | Task |

--- a/skills/designer/review-boundary/SKILL.md
+++ b/skills/designer/review-boundary/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: review-boundary
+description: "When Designer reviews vs builds. Clear boundaries for autonomous action."
+metadata:
+  version: 1.0.0
+  type: policy
+---
+
+# Designer: Review vs Build Boundary
+
+## Review Only (no code changes)
+- PRs from AO/Mechanic that touch frontend — review for design compliance
+- Existing component modifications — check against design-system tokens
+- Accessibility audit — flag issues, don't fix directly
+
+## Build Autonomously ("Build it, ship it")
+- New UI components requested by Architect or Strategist
+- Design system token updates
+- Brand asset integration (from Forge)
+- Style guide documentation updates
+- Figma-to-code implementation when directed
+
+## Escalate (don't proceed)
+- Changes to app logic disguised as "design updates"
+- Requests to modify API responses or data models
+- Breaking changes to existing component APIs
+- Changes that affect performance (heavy animations, large assets)
+
+## Coordination
+- Sync with Forge on any brand/asset changes
+- Notify Architect before any cross-cutting style changes
+- Post to #yclaw-development after any autonomous builds

--- a/skills/mechanic/safety-boundaries/SKILL.md
+++ b/skills/mechanic/safety-boundaries/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: mechanic-safety-boundaries
+description: "Hard limits on Mechanic operations. These cannot be overridden by task directives."
+metadata:
+  version: 1.0.0
+  type: policy
+---
+
+# Mechanic Safety Boundaries
+
+## Hard Limits (cannot be overridden)
+
+1. **No direct-to-main commits** — always use branches
+2. **No CI workflow modifications** without explicit Architect approval in the task payload
+3. **No secret/credential handling** — if a task involves secrets, escalate immediately
+4. **No cross-repo operations** — one repo per task
+5. **No force pushes** — ever
+6. **No tag creation or release operations**
+7. **No issue creation or management** — only PR comments
+
+## Required in Every Task Completion
+
+- Publish `mechanic:task_completed` with:
+  - `files_modified`: list of files changed
+  - `files_count`: number of files changed
+  - `operation_type`: which whitelist category
+  - `branch`: branch name
+  - `pr_number`: if PR was created/updated
+
+## Required in Every Task Failure
+
+- Publish `mechanic:task_failed` with:
+  - `reason`: one of [outside_whitelist, complex_conflict, ambiguous_task, scope_exceeded, escalation_required]
+  - `detail`: human-readable explanation
+  - `original_task`: the task that was requested

--- a/skills/mechanic/task-whitelist/SKILL.md
+++ b/skills/mechanic/task-whitelist/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: mechanic-task-whitelist
+description: "Defines the exact operations Mechanic is allowed to perform. Load before executing any task."
+metadata:
+  version: 1.0.0
+  type: policy
+---
+
+# Mechanic Task Whitelist
+
+> You are a constrained task runner. You may ONLY perform operations listed below.
+> If a task requires anything not on this list, publish `mechanic:task_failed` with
+> reason "outside_whitelist" and stop.
+
+## Allowed Operations
+
+### 1. Lockfile Sync
+- Run package manager install/update to regenerate lockfiles
+- Commit updated lockfile only
+- Allowed files: package-lock.json, yarn.lock, pnpm-lock.yaml, Cargo.lock
+
+### 2. Code Formatting
+- Run project formatter (prettier, eslint --fix, rustfmt)
+- Commit formatted files only
+- Do NOT change any logic — formatting only
+
+### 3. Linting Fixes
+- Run project linter with auto-fix
+- Commit only auto-fixable issues
+- If manual fixes required, comment on PR and escalate to Architect
+
+### 4. Branch Rebasing
+- Rebase feature branches onto main/target
+- Resolve only trivial conflicts (whitespace, lockfile)
+- If conflicts require judgment, publish `mechanic:task_failed` with reason "complex_conflict"
+
+### 5. CI Config Updates (limited)
+- Update dependency versions in CI config when explicitly directed
+- Do NOT modify CI logic, workflow structure, or secrets
+
+## Boundaries
+
+- **Max files per task:** 10. If a task would touch more than 10 files, stop and escalate.
+- **No feature code:** Never write application logic, business rules, or new functions.
+- **No architecture:** Never create new files, modules, or directory structures.
+- **No dependency additions:** Never add new packages. Only update existing ones when directed.
+- **No deletions:** Never delete files. Only modify existing ones within whitelist.
+- **Always branch:** Never commit directly to main. Always use a feature branch.
+
+## Escalation
+
+If any of these conditions are true, publish `mechanic:task_failed` and stop:
+- Task description is ambiguous
+- Task requires modifying files not in whitelist categories
+- Task would affect more than 10 files
+- Merge conflicts require understanding code logic
+- Task seems to require feature development disguised as maintenance


### PR DESCRIPTION
## Development Department — P0 Critical Fixes

Addresses the critical issues found in the Development department audit. Single branch, 1-of-3 commits (P1 and P2 will stack).

### Changes

1. **Remove `deploy:execute` from Architect** — permission contradicted workflow policy ("NEVER execute deployments"). Kept `deploy:assess` (read-only assessment is appropriate).
2. **Enable Architect heartbeat** — `precheck.enabled: false → true` (maxSilenceHours: 6 already set). Most critical dev agent had no monitoring.
3. **Slack → Discord** across all dev prompts + README (zero remaining `slack` refs in any dev file).
4. **Resolve ALL placeholders**:
   - `architect-workflow.md`: 2x `your-org` → `YClawAI` (including `your-org/yclaw` → `YClawAI/yclaw`)
   - `designer-workflow.md`: 11x `[your-*]` resolved to `YClawAI`, `yclaw`, `#yclaw-development`, `yclaw-style-guide`, `brand-voice.md`; `[Your Org]` Stitch template → `YClawAI`
   - `daily-standup-dev.md`: 2x `[your-development-channel]` → `#yclaw-development`; "your development agents" → "Architect, Designer, Mechanic"; "your AI Chief of Staff" → "Strategist"
   - `designer.yaml` data source: `your-org/STYLE-GUIDE` → `YClawAI/yclaw-style-guide` with TODO comment
5. **Fix `codegen:status` → `ao:status`** — referenced action not in YAML, corrected to actual action name (was in `evaluate_and_delegate` task).
6. **Remove `CUSTOMIZE FOR YOUR ORGANIZATION` markers** from `designer-workflow.md` and `daily-standup-dev.md`.
7. **README updates** — slack:message → discord:message in actions table; added Mechanic agent row, Mechanic section, Mechanic column in actions table (including `github:commit_batch`, `discord:thread_reply` rows for Mechanic-unique actions); added `mechanic.yaml` to config files list.

### Audit drift (no-ops, flagged per (b) policy)

These P0 items were already correct on main at branch time and required no change:

- **P0-2 Mechanic model name** — already `claude-sonnet-4-6` on main (audit was stale).
- **P0-5 "Add `codegen:status` to Architect actions OR remove workflow reference"** — chose the second branch (removed reference + fixed to real action `ao:status`). No YAML action addition needed.

### Audit reference
https://gist.github.com/DannyDesert/f97dfdb0cebf7039a1a9d161a80faf93

### Verification

- ✅ `grep -n -i slack` across all dev files: 0 hits
- ✅ `grep -n your-org\|\[your-\|CUSTOMIZE FOR YOUR` across all dev files + YAMLs: 0 hits
- ✅ `grep codegen:status`: 0 hits
- ✅ `grep deploy:execute departments/development/architect.yaml`: 0 hits
- ✅ `grep yclaw-style-guide prompts/designer-workflow.md`: TODO comment present
- ✅ `npm test -- tests/config-validation.test.ts`: 14/14 passing
- ✅ Diff scope: exactly 6 files (no out-of-scope changes)

### Out of scope (deferred to P1/P2)

- Missing `escalation-policy.md` / `executive-directive.md` on Designer — P1
- Designer's `claudeception:reflect` model still on old name — P1
- Mechanic heartbeat still disabled — P1 (if desired; not in original P0)
- stale_issue_sweep frequency — already at every 6h on main (P1 audit drift)
- README subscriptions/cron tables stale — P1 ("reconcile README/YAML action mismatches")
- architect-workflow.md split — P2