### PR TITLE
chore(ao): Upgrade Claude Code model to Opus 4.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,7 +90,7 @@ GEMINI_API_KEY=
 
 # Default LLM routing (overridable per-agent in departments/*.yaml)
 LLM_PROVIDER=anthropic
-LLM_MODEL=claude-opus-4-6
+LLM_MODEL=claude-opus-4-7
 # Defaults to LLM_PROVIDER when blank
 ONBOARDING_LLM_PROVIDER=
 # Defaults to LLM_MODEL when blank
@@ -121,7 +121,7 @@ LITELLM_DATABASE_URL=
 EXECUTOR_TYPE=pi
 # Legacy: ACPX_SERVICE_URL and ACPX_API_KEY removed — Pi replaces ACP
 PI_CODING_AGENT_ENABLED=true
-PI_DEFAULT_MODEL=claude-opus-4-6
+PI_DEFAULT_MODEL=claude-opus-4-7
 PI_DEFAULT_PROVIDER=anthropic
 SESSION_TTL_MS=7200000
 MAX_CONCURRENT_SESSIONS=50

--- a/ao/agent-orchestrator.yaml
+++ b/ao/agent-orchestrator.yaml
@@ -29,6 +29,7 @@ projects:
 
     agentConfig:
       permissions: permissionless
+      model: claude-opus-4-7
 
     scm:
       plugin: github


### PR DESCRIPTION
## Changes

- **`ao/agent-orchestrator.yaml`**: Added `model: claude-opus-4-7` to project agentConfig — AO will now pass `--model claude-opus-4-7` to Claude Code CLI
- **`.env.example`**: Updated `LLM_MODEL` and `PI_DEFAULT_MODEL` defaults from `claude-opus-4-6` → `claude-opus-4-7`

## What's NOT in this PR

~40 other references to `claude-opus-4-6` across:
- Department YAMLs (strategist, architect, scout)
- LiteLLM proxy config and fallback chains
- Source code hardcoded fallbacks (`worker.ts`, `pi-executor.ts`, `fleet/route.ts`)
- Test fixtures
- Documentation (README, docs/)
- Pricing/token tables

These should be swept in a follow-up PR to keep this change focused and deployable.

## Deployment

After merge, the patient zero instance needs a redeploy to pick up the new AO config.