### PR TITLE
fix: Discord inbound rate limit — admin bypass + raise defaults

### DIFF
--- a/packages/core/src/triggers/discord-event-handler.ts
+++ b/packages/core/src/triggers/discord-event-handler.ts
@@ -14,11 +14,22 @@ const DISCORD_HANDLER_REGISTERED = '__yclawDiscordEventHandlerRegistered';
 // @mentions that trigger agent task executions.
 
 /** Max events published per user per rolling window. */
-const INBOUND_MAX_PER_USER = Number(process.env.DISCORD_INBOUND_RATE_LIMIT ?? 5);
+const INBOUND_MAX_PER_USER = Number(process.env.DISCORD_INBOUND_RATE_LIMIT ?? 30);
 /** Rolling window in milliseconds (default 1 hour). */
 const INBOUND_WINDOW_MS = Number(process.env.DISCORD_INBOUND_WINDOW_MS ?? 3_600_000);
 /** Max events published globally per rolling window. */
-const INBOUND_GLOBAL_MAX = Number(process.env.DISCORD_INBOUND_GLOBAL_LIMIT ?? 30);
+const INBOUND_GLOBAL_MAX = Number(process.env.DISCORD_INBOUND_GLOBAL_LIMIT ?? 120);
+/**
+ * Comma-separated Discord user IDs that bypass inbound rate limits entirely.
+ * Typically org admins / operators who need unrestricted access during testing
+ * or active management sessions.
+ */
+const INBOUND_RATE_LIMIT_BYPASS_IDS = new Set(
+  (process.env.DISCORD_RATE_LIMIT_BYPASS_IDS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
 
 interface RateBucket {
   timestamps: number[];
@@ -30,6 +41,11 @@ class InboundRateLimiter {
 
   /** Returns true if the event should be allowed through. */
   allow(userId: string): boolean {
+    // Admin/operator bypass — never rate-limit whitelisted user IDs.
+    if (INBOUND_RATE_LIMIT_BYPASS_IDS.has(userId)) {
+      return true;
+    }
+
     const now = Date.now();
     const cutoff = now - INBOUND_WINDOW_MS;
 


### PR DESCRIPTION
## Problem

Admin user (Troy) getting rate-limited by YCLAW's own inbound Discord event handler:

```
Inbound rate limit: per-user cap reached {userId: '222767769085542402', limit: 5, windowMs: 3600000}
Dropping rate-limited Discord message
```

The per-user cap was set to **5 messages per hour** — way too aggressive for an admin actively testing during a soak period. Messages were being silently dropped, making agents appear unresponsive.

## Fix

**1. Admin bypass** (new `DISCORD_RATE_LIMIT_BYPASS_IDS` env var)
- Comma-separated Discord user IDs that skip rate limiting entirely
- Set this to your admin/operator user IDs

**2. Raised defaults**
- Per-user: 5 → **30** messages/hour
- Global: 30 → **120** messages/hour
- Original values were designed for anti-spam against external users, not for normal org usage

## Env Vars

| Variable | Default | Description |
|----------|---------|-------------|
| `DISCORD_RATE_LIMIT_BYPASS_IDS` | (empty) | Admin user IDs that bypass limits |
| `DISCORD_INBOUND_RATE_LIMIT` | 30 | Max messages per user per hour |
| `DISCORD_INBOUND_WINDOW_MS` | 3600000 | Rolling window in ms |
| `DISCORD_INBOUND_GLOBAL_LIMIT` | 120 | Max messages globally per hour |

## After merge

Set in ECS task definition or .env:
```
DISCORD_RATE_LIMIT_BYPASS_IDS=222767769085542402
```

## Changes
- 1 file changed: `packages/core/src/triggers/discord-event-handler.ts`
- No breaking changes — all new env vars are optional with backward-compatible defaults