### PR TITLE
chore(ao): Add yclaw-site as AO project

### DIFF
--- a/ao/agent-orchestrator.yaml
+++ b/ao/agent-orchestrator.yaml
@@ -39,6 +39,22 @@ projects:
     postCreate:
       - npm install
 
+  yclaw-site:
+    name: YClaw Site
+    repo: YClawAI/yclaw-site
+    path: /data/worktrees/YClawAI__yclaw-site
+    defaultBranch: main
+    sessionPrefix: yclaw-site
+
+    agentConfig:
+      permissions: permissionless
+      model: claude-opus-4-7
+
+    scm:
+      plugin: github
+    tracker:
+      plugin: github
+
 
 # Notification channels — webhook for callbacks to yclaw
 notifiers:


### PR DESCRIPTION
Adds `YClawAI/yclaw-site` as a second AO project so Architect can dispatch Claude Code (Opus 4.7) against the landing page repo.

**Context:** Architect received a landing page redesign directive but couldn't execute — AO only knew about `YClawAI/YClaw`. This unblocks it.

**Longer-term:** Architect should have the ability to add projects to AO config dynamically (capability gap to address).