### PR TITLE
fix(ember): canonical link table to prevent URL hallucination

### DIFF
--- a/prompts/brand-voice.md
+++ b/prompts/brand-voice.md
@@ -67,6 +67,8 @@ YClaw is an open-source AI agent orchestration framework. It lets AI agents run 
 - GitHub: https://github.com/YClawAI/YClaw
 - Discord: https://discord.com/invite/HqFDg4UHXx
 
+**Copy these URLs exactly. The GitHub org is `YClawAI` — not `yclaw-ai`, not `YClaw-AI`, not `yclaw`. Never improvise a URL.**
+
 ## Legal Rails
 - **NEVER use:** Deceptive claims about capabilities, fabricated benchmarks, impersonation of other projects, or unsubstantiated superiority claims
 - **NEVER reference:** Internal infrastructure details, API keys, credentials, or other organizations' proprietary information

--- a/prompts/content-templates.md
+++ b/prompts/content-templates.md
@@ -1,9 +1,15 @@
 # Content Templates
 
-## Active Channels
-- X/Twitter (@YClaw_ai — currently suspended, posting via @TroyMurs)
-- Discord (https://discord.com/invite/HqFDg4UHXx)
-- GitHub (https://github.com/YClawAI/YClaw)
+## Canonical Links — COPY EXACTLY, NEVER IMPROVISE
+
+| Resource | Exact URL | Common mistakes to avoid |
+|----------|-----------|-------------------------|
+| GitHub | https://github.com/YClawAI/YClaw | ~~github.com/yclaw-ai/yclaw~~, ~~github.com/yclaw/YClaw~~, ~~github.com/YClaw-AI/yclaw~~ |
+| Website | https://yclaw.ai | ~~yclaw.com~~, ~~www.yclaw.ai~~ |
+| Discord | https://discord.com/invite/HqFDg4UHXx | Do not generate invite links — use this exact one |
+| X/Twitter | @YClaw_ai (currently suspended, posting via @TroyMurs) | ~~@YClawAI~~, ~~@yclaw_ai~~, ~~@yclaw~~ |
+
+**RULE: Never type a URL from memory. Copy from the table above. GitHub org is `YClawAI` (capital Y, capital C, capital A, capital I, no hyphens).**
 
 ## Template 1: Feature Announcement
 
@@ -90,3 +96,5 @@
 - Swearing OK when natural ("that's fucking brilliant" > sterile corporate praise)
 
 **CRITICAL: YClaw is AI agent orchestration infrastructure. NOT a DeFi protocol. NOT a token. NOT creator economy.**
+
+**LINK INTEGRITY: Every URL in a post MUST be copied verbatim from the Canonical Links table at the top of this file. If you are unsure of a URL, omit it rather than guess. A wrong link is worse than no link.**


### PR DESCRIPTION
## Problem
Ember posted tweets with `github.com/yclaw-ai/yclaw` instead of the correct `github.com/YClawAI/YClaw`. Classic LLM hallucination — knows the concept but gets casing/format wrong.

## Fix
- **Canonical Links table** in `content-templates.md` — exact URLs with explicit wrong-URL examples to avoid
- **LINK INTEGRITY rule** — copy from table, never guess. Wrong link > no link
- **brand-voice.md reinforcement** — same guardrail where Key Links are listed

## Why this works
LLMs are much better at copying from an explicit table than constructing URLs from memory. The negative examples (strikethrough wrong URLs) give the model concrete patterns to avoid.

## Also needed (separate issue)
Duplicate posting fix — Ember posted nearly identical content twice simultaneously. Filed as separate issue.