### PR TITLE
fix(ao): add yclaw-site to YCLAW_REPOS — unblocks Opus 4.7 landing page test

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -888,7 +888,7 @@ resource "aws_ecs_task_definition" "ao" {
       environment = [
         { name = "YCLAW_AO_PROJECT", value = "yclaw" },
         { name = "NODE_ENV", value = var.environment },
-        { name = "YCLAW_REPOS", value = "YClawAI/YClaw" },
+        { name = "YCLAW_REPOS", value = "YClawAI/YClaw YClawAI/yclaw-site" },
         { name = "YCLAW_AO_OVERLAY_REPO", value = "YClawAI/YClaw" },
         { name = "AO_CALLBACK_URL", value = "http://yclaw-agents.yclaw.internal:3000/api/ao/callback" },
         { name = "AO_CALLBACK_FALLBACK_URL", value = "https://agents.yclaw.ai/api/ao/callback" },


### PR DESCRIPTION
## Problem
AO container crash-looped (task def `:28`, exit code 1) after PR #139 added `yclaw-site` to `agent-orchestrator.yaml`. Root cause: `YCLAW_REPOS` env var only listed `YClawAI/YClaw`, so `yclaw-site` was never cloned to `/data/worktrees/`. AO started with a config referencing a non-existent path.

## Fix
Add `YClawAI/yclaw-site` to the space-separated `YCLAW_REPOS` value in Terraform so the entrypoint clones it before AO boots.

## What this unblocks
Troy's original request: Architect builds the yclaw.ai landing page redesign via AO using Opus 4.7 — the end-to-end system test.