### PR TITLE
fix(ao): remove GITHUB_TOKEN secret — unblocks AO deploy

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -895,7 +895,8 @@ resource "aws_ecs_task_definition" "ao" {
       ]
 
       secrets = [
-        { name = "GITHUB_TOKEN", valueFrom = "${aws_secretsmanager_secret.agent_secrets.arn}:GITHUB_TOKEN::" },
+        # GITHUB_TOKEN removed — AO uses GitHub App auth (GITHUB_APP_ID/PRIVATE_KEY/INSTALLATION_ID).
+        # Injecting GITHUB_TOKEN conflicts with the App token flow and crashes the entrypoint.
         { name = "ANTHROPIC_API_KEY", valueFrom = "${aws_secretsmanager_secret.agent_secrets.arn}:ANTHROPIC_API_KEY::" },
         { name = "REDIS_URL", valueFrom = "${aws_secretsmanager_secret.agent_secrets.arn}:REDIS_URL::" },
         { name = "OPENAI_API_KEY", valueFrom = "${aws_secretsmanager_secret.agent_secrets.arn}:OPENAI_API_KEY::" },


### PR DESCRIPTION
## Problem
AO container crash-loops (exit code 1) on task def :28/:29. Old :26 still running.

**Root cause:** `GITHUB_TOKEN` secret was added to AO's task def. AO uses GitHub App auth (`token-manager.mjs` → dynamic tokens). The `GITHUB_TOKEN` env var conflicts — `gh auth login` ignores the piped App token and uses the env var instead. With `set -e`, the entrypoint dies silently with zero diagnostic output.

## Evidence
- Task def :26 (no GITHUB_TOKEN secret) = works fine
- Task def :29 (has GITHUB_TOKEN secret) = crash-loops
- CloudWatch shows only 3 log lines before crash — classic `set -e` silent kill

## Fix
Remove `GITHUB_TOKEN` from AO's secrets block. GitHub App auth is the primary and correct method.

## IMPORTANT
This change requires `terraform apply` to take effect. CI only rebuilds Docker images and registers new task defs — it does NOT apply Terraform changes.