### PR TITLE
fix(arch): restore Architect→AO separation of concerns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -691,6 +691,47 @@ Configure via ECS task definition environment variable `REDIS_URL`.
 
 ---
 
+## AO Execution Policy
+
+AO (Agent Orchestrator) is an **execution agent**. It implements tasks assigned to it
+by the Architect via `architect:build_directive` events. AO does not plan, triage, or
+prioritize — that is the Architect's job.
+
+### AO Does
+
+- Execute coding tasks from `build_directive` events or assigned issues
+- Open PRs with clear descriptions linking to the source issue
+- Report blockers to Architect via `ao:task_blocked` events
+- Comment on its assigned issue with status updates
+- Report completion via `ao:task_completed` events
+- Create branches, commit, push, and open PRs
+
+### AO Does NOT
+
+- Create GitHub issues (no `gh issue create`, no `github:create_issue`)
+- Scan the codebase for tech debt or improvement opportunities
+- Triage, label, or prioritize issues
+- Self-assign work or pick up unassigned issues
+- File follow-up issues from its own PRs
+- Decide what is worth working on — that is the Architect's job
+- Close or update issue metadata (labels, assignees, milestones)
+- Run cron-based codebase scans or discovery loops
+
+### Observations Protocol
+
+If AO discovers a problem while coding that is outside the scope of the current
+directive, it notes it in its PR description under a `## Observations for Architect`
+section. The Architect will decide if it becomes an issue.
+
+### Authority Boundary
+
+The build_directive is AO's sole work intake mechanism. Without an explicit
+`architect:build_directive` event or a GitHub issue assignment, AO has no work to do.
+This gate prevents self-referential loops where AO scans, files, triages, and executes
+its own work.
+
+---
+
 ## Coding Guidelines
 
 ### Error Handling

--- a/ao/entrypoint.sh
+++ b/ao/entrypoint.sh
@@ -291,6 +291,34 @@ if [ ! -f "$AO_HOME/.claude/settings.json" ] && [ -f "/home/ao/.claude/settings.
   cp /home/ao/.claude/settings.json "$AO_HOME/.claude/settings.json"
 fi
 
+# --- AO Execution Policy (user-level CLAUDE.md) ---
+# This constrains Claude Code sessions across ALL repos AO works on.
+# The repo-level CLAUDE.md has the full policy; this is the cross-repo enforcement.
+cat > "$AO_HOME/.claude/CLAUDE.md" << 'AO_POLICY_EOF'
+# AO Execution Policy
+
+You are an execution agent. You implement tasks assigned to you.
+
+## You DO
+- Execute coding tasks from build_directives or assigned issues
+- Open PRs with clear descriptions linking to the issue
+- Report blockers to Architect
+- Comment on your assigned issue with status updates
+
+## You DO NOT
+- Create GitHub issues
+- Scan the codebase for tech debt or improvement opportunities
+- Triage, label, or prioritize issues
+- Self-assign work
+- File follow-up issues from your own PRs
+- Decide what is worth working on — that is Architect's job
+
+If you discover a problem while coding, note it in your PR description
+under a "## Observations for Architect" section. Architect will decide
+if it becomes an issue.
+AO_POLICY_EOF
+chown ao:ao "$AO_HOME/.claude/CLAUDE.md" 2>/dev/null || true
+
 # Symlink ao user's HOME directories to AO_HOME so Claude Code finds configs
 mkdir -p /home/ao/.config
 rm -rf /home/ao/.claude /home/ao/.config/gh 2>/dev/null || true

--- a/departments/development/architect.yaml
+++ b/departments/development/architect.yaml
@@ -118,6 +118,11 @@ triggers:
     event: architect:rebase_needed
     task: evaluate_rebase
 
+  # New repo onboarding
+  - type: event
+    event: github:repository_created
+    task: onboard_new_repo
+
   - type: event
     event: claudeception:reflect
     task: self_reflection
@@ -129,12 +134,18 @@ triggers:
 
 actions:
   - github:get_contents
+  - github:get_multiple_files
   - github:get_diff
   - github:get_issue
   - github:create_issue
+  - github:close_issue
   - github:list_issues
   - github:update_issue
+  - github:get_pr
+  - github:list_prs
   - github:pr_comment
+  - github:pr_review
+  - github:compare_commits
   - github:add_labels
   - github:remove_label
   - ao:status
@@ -147,6 +158,8 @@ actions:
   - discord:react
   - event:publish
   - deploy:assess
+  - deploy:architect_approve
+  - deploy:status
 
 data_sources: []
 
@@ -163,6 +176,7 @@ event_subscriptions:
   - strategist:architect_directive
   - deploy:review
   - architect:rebase_needed
+  - github:repository_created
 
 event_publications:
   - standup:report


### PR DESCRIPTION
## What
- Add AO Execution Policy to CLAUDE.md constraining AO to execute-only (no issue creation, labeling, triage, self-assignment, codebase scanning)
- Write cross-repo AO user-level CLAUDE.md in `ao/entrypoint.sh` so policy applies to all repos AO works on
- Add 8 missing actions to Architect YAML (`close_issue`, `get_pr`, `list_prs`, `pr_review`, `compare_commits`, `get_multiple_files`, `deploy:architect_approve`, `deploy:status`)
- Add `github:repository_created` → `onboard_new_repo` trigger + subscription

## Why
AO had CTO-level authority — scanning codebases, filing issues, triaging, and executing in a self-referential loop. The `build_directive` gate from Architect is the structural fix that kills the loop: AO cannot work without an explicit assignment.

## Test plan
- [x] 14/14 config-validation tests pass
- [x] All 8 new actions verified in runtime (`packages/core/src/actions/`)
- [x] `github:repository_created` event in ACL (`event-acl.ts`)
- [x] `onboard_new_repo` task referenced in workflow docs
- [x] `deploy:architect_approve` cross-referenced in YAML + workflow
- [x] No duplicate actions, no `[your-*]` or `your-org` placeholders
- [x] YAML syntax valid
- [x] Heredoc single-quoted (no variable expansion)
- [x] Codex review: 14/14 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)