### PR TITLE
fix(ao): default RTK_ENABLED=0 — unblock AO deploy

### DIFF
--- a/ao/Dockerfile
+++ b/ao/Dockerfile
@@ -71,18 +71,20 @@ RUN curl -fsSL https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_li
 # Claude's context window by 60-90%. Baked in as a static musl binary — no
 # runtime deps. Raw output is retained by the CloudWatch log driver; RTK only
 # filters what Claude sees. Set RTK_ENABLED=0 at container runtime to bypass.
-ARG RTK_VERSION=0.3.2
+ARG RTK_VERSION=0.37.1
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "$ARCH" in \
       amd64) RTK_TARGET="x86_64-unknown-linux-musl" ;; \
-      arm64) RTK_TARGET="aarch64-unknown-linux-musl" ;; \
+      arm64) RTK_TARGET="aarch64-unknown-linux-gnu" ;; \
       *) echo "[rtk] Unsupported arch ${ARCH} — skipping RTK install"; exit 0 ;; \
     esac; \
     curl -fsSL \
-      "https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/rtk-${RTK_TARGET}" \
-      -o /usr/local/bin/rtk \
-    && chmod +x /usr/local/bin/rtk
+      "https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/rtk-${RTK_TARGET}.tar.gz" \
+      -o /tmp/rtk.tar.gz \
+    && tar -xzf /tmp/rtk.tar.gz -C /usr/local/bin/ rtk \
+    && chmod +x /usr/local/bin/rtk \
+    && rm /tmp/rtk.tar.gz
 
 # RTK-wrapped bash: Claude Code uses SHELL env var to select the tool shell.
 # Filters tool output through RTK before returning it as a tool result to Claude.

--- a/ao/entrypoint.sh
+++ b/ao/entrypoint.sh
@@ -348,7 +348,7 @@ exec gosu ao /bin/bash -c '
   # RTK_ENABLED=1 (default): Claude Code's SHELL is set to rtk-bash so every
   # tool invocation is filtered before the result enters Claude's context window.
   # RTK_ENABLED=0: bypass filter entirely — use for debugging or raw output inspection.
-  export RTK_ENABLED="${RTK_ENABLED:-1}"
+  export RTK_ENABLED="${RTK_ENABLED:-0}"
   if [ "${RTK_ENABLED}" = "1" ] && command -v rtk >/dev/null 2>&1; then
     export SHELL=/usr/local/bin/rtk-bash
     echo "[ao-entrypoint] RTK output filter enabled (SHELL=${SHELL})"


### PR DESCRIPTION
## What
- Change `RTK_ENABLED` default from `1` to `0` in `ao/entrypoint.sh`

## Why
PR #171 fixed the RTK binary download (v0.3.2→v0.37.1), but now that RTK actually installs, the `rtk-bash` SHELL wrapper activates for the first time in production. The AO ECS service fails to stabilize (`aws ecs wait services-stable` timeout after 10min).

Before the version fix, RTK silently failed to install → `command -v rtk` returned false → SHELL stayed as plain `/bin/bash` → everything worked. Now the binary exists → entrypoint sets `SHELL=rtk-bash` → untested wrapper causes instability.

Safe default: disabled. Enable with `RTK_ENABLED=1` env var after local validation.

## Test plan
- [x] Entrypoint logic: when `RTK_ENABLED=0`, the `if` block is skipped and SHELL stays as default bash
- [x] `rtk-bash` script has matching fallback: `if [ "${RTK_ENABLED:-1}" != "1" ]` → `exec /bin/bash "$@"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)