### PR TITLE
[codex] Add one-line guided installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,16 +133,45 @@ See [`AI-HANDSHAKE.md`](./AI-HANDSHAKE.md) for the full flow your assistant shou
 ## Quick Start
 
 ```bash
-git clone https://github.com/YClawAI/yclaw.git
-cd yclaw
-cp .env.example .env
-# Edit .env — add ANTHROPIC_API_KEY (or OPENAI_API_KEY)
-docker compose up -d --build
+curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash
 ```
 
-> **First boot takes 2-3 minutes** while Docker builds the API and dashboard
-> images and the migrate one-shot runs against postgres. Watch progress with
-> `docker compose logs -f api`. Subsequent runs can drop the `--build` flag.
+The installer clones YCLAW into `~/yclaw`, installs dependencies, builds the
+local CLI, runs `yclaw init`, and runs `yclaw doctor`. It will not deploy until
+doctor passes, so missing GitHub/LLM credentials stop before a broken system can
+start.
+
+Useful variants:
+
+```bash
+# Non-interactive local config generation
+curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash -s -- --preset local-demo --non-interactive
+
+# AWS/Terraform starter
+curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash -s -- --preset aws-production
+
+# Custom install directory
+curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash -s -- --dir ./yclaw
+```
+
+Before deployment, fill `~/yclaw/.env` with:
+
+- one LLM key, such as `ANTHROPIC_API_KEY`
+- `GITHUB_OWNER`, `GITHUB_REPO`, and `YCLAW_REPOS`
+- GitHub App credentials or a local-only `GITHUB_TOKEN`
+- `GITHUB_WEBHOOK_SECRET`, also configured on the GitHub App webhook
+
+Manual source install:
+
+```bash
+git clone https://github.com/YClawAI/YClaw.git
+cd YClaw
+npm ci
+npm run build --workspace=packages/cli
+npx --no-install yclaw init --preset local-demo
+npx --no-install yclaw doctor
+npx --no-install yclaw deploy --detach --bootstrap-output-file ./yclaw-root-bootstrap.json
+```
 
 ### Verify
 

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -50,6 +50,7 @@ YCLAW_SETUP_TOKEN=
 # GITHUB_APP_ID=           # GitHub App ID for AO's git operations
 # GITHUB_APP_PRIVATE_KEY=  # GitHub App private key (base64 or PEM)
 # GITHUB_APP_INSTALLATION_ID=  # GitHub App installation ID
+# GITHUB_WEBHOOK_SECRET=   # Must match the GitHub App webhook secret
 
 # ─── Mission Control ─────────────────────────────────────────────────────
 MC_PORT=3001

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,10 +17,40 @@ This guide gets you from nothing to a running YCLAW instance with Mission Contro
 
 ---
 
-## Step 1: Initialize
+## One-Line Guided Install
 
 ```bash
-npx yclaw init --preset local-demo
+curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash
+```
+
+This clones YCLAW into `~/yclaw`, installs dependencies, builds the local CLI,
+runs `yclaw init`, and runs `yclaw doctor`. The installer refuses to deploy
+until doctor passes, so missing LLM/GitHub credentials stop before any unhealthy
+containers are started.
+
+Useful variants:
+
+```bash
+# Generate local-demo config without prompts
+curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash -s -- --preset local-demo --non-interactive
+
+# Start an AWS/Terraform config
+curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash -s -- --preset aws-production
+
+# Choose a target directory
+curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash -s -- --dir ./yclaw
+```
+
+---
+
+## Manual Step 1: Initialize
+
+```bash
+git clone https://github.com/YClawAI/YClaw.git
+cd YClaw
+npm ci
+npm run build --workspace=packages/cli
+npx --no-install yclaw init --preset local-demo
 ```
 
 This generates three files:
@@ -31,24 +61,29 @@ This generates three files:
 | `.env` | Credentials and secrets (mode 0600) |
 | `.yclaw-cli.json` | CLI metadata sidecar |
 
-Edit `.env` and set your `ANTHROPIC_API_KEY` (or whichever LLM provider you chose).
+Edit `.env` and set:
+
+- one LLM key, such as `ANTHROPIC_API_KEY`
+- `GITHUB_OWNER`, `GITHUB_REPO`, and `YCLAW_REPOS`
+- GitHub App credentials or a local-only `GITHUB_TOKEN`
+- `GITHUB_WEBHOOK_SECRET`, also configured on the GitHub App webhook
 
 ---
 
-## Step 2: Validate
+## Manual Step 2: Validate
 
 ```bash
-npx yclaw doctor
+npx --no-install yclaw doctor
 ```
 
 The doctor runs 10+ checks: Node version, Docker availability, port availability, config schema validation, credential format. Fix anything marked FAIL before proceeding.
 
 ---
 
-## Step 3: Deploy
+## Manual Step 3: Deploy
 
 ```bash
-npx yclaw deploy --detach
+npx --no-install yclaw deploy --detach --bootstrap-output-file ./yclaw-root-bootstrap.json
 ```
 
 This starts Docker Compose with MongoDB, Redis, PostgreSQL, the Core runtime, and Mission Control. The `--detach` flag runs containers in the background.
@@ -68,7 +103,7 @@ You'll see the dashboard with system health, agent status, and the onboarding pr
 ## Step 5: Check Status
 
 ```bash
-npx yclaw status
+npx --no-install yclaw status
 ```
 
 Shows infrastructure health, channel status, agent counts, and recent errors. Exit code 0 means healthy.
@@ -91,8 +126,8 @@ In Mission Control, walk through the onboarding flow. Answer questions about you
 ## Step 7: Tear Down (when done)
 
 ```bash
-npx yclaw destroy              # Stop containers
-npx yclaw destroy --volumes    # Stop containers AND delete data
+npx --no-install yclaw destroy              # Stop containers
+npx --no-install yclaw destroy --volumes    # Stop containers AND delete data
 ```
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+YCLAW_REPO="${YCLAW_REPO:-https://github.com/YClawAI/YClaw.git}"
+YCLAW_BRANCH="${YCLAW_BRANCH:-main}"
+YCLAW_DIR="${YCLAW_DIR:-$HOME/yclaw}"
+YCLAW_PRESET="${YCLAW_PRESET:-local-demo}"
+
+NON_INTERACTIVE=0
+YES=0
+NO_DEPLOY=0
+FORCE_INIT=0
+
+usage() {
+  cat <<'USAGE'
+YCLAW one-line installer
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/YClawAI/YClaw/main/install.sh | bash -s -- --preset local-demo --non-interactive
+
+Options:
+  --dir <path>            Install directory (default: ~/yclaw)
+  --repo <url>            Git repository URL
+  --branch <name>         Git branch (default: main)
+  --preset <name>         local-demo, small-team, or aws-production
+  --non-interactive       Run yclaw init without prompts
+  --yes                   Deploy automatically after doctor passes
+  --no-deploy             Stop after doctor passes
+  --force                 Pass --force to yclaw init
+  -h, --help              Show help
+USAGE
+}
+
+log() {
+  printf '\033[1;34m==>\033[0m %s\n' "$*"
+}
+
+warn() {
+  printf '\033[1;33mWARN\033[0m %s\n' "$*" >&2
+}
+
+die() {
+  printf '\033[1;31mERROR\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir)
+      YCLAW_DIR="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      YCLAW_REPO="${2:-}"
+      shift 2
+      ;;
+    --branch)
+      YCLAW_BRANCH="${2:-}"
+      shift 2
+      ;;
+    --preset)
+      YCLAW_PRESET="${2:-}"
+      shift 2
+      ;;
+    --non-interactive)
+      NON_INTERACTIVE=1
+      shift
+      ;;
+    --yes|-y)
+      YES=1
+      shift
+      ;;
+    --no-deploy)
+      NO_DEPLOY=1
+      shift
+      ;;
+    --force)
+      FORCE_INIT=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required. Install it, then rerun this installer."
+}
+
+node_major() {
+  node -p "Number(process.versions.node.split('.')[0])"
+}
+
+run_tty() {
+  if [[ -r /dev/tty ]]; then
+    "$@" </dev/tty
+  else
+    "$@"
+  fi
+}
+
+prompt_yes_no() {
+  local prompt="$1"
+  local answer=""
+  if [[ ! -r /dev/tty ]]; then
+    return 1
+  fi
+  printf '%s [y/N] ' "$prompt" >/dev/tty
+  IFS= read -r answer </dev/tty || true
+  [[ "$answer" == "y" || "$answer" == "Y" || "$answer" == "yes" || "$answer" == "YES" ]]
+}
+
+ensure_prerequisites() {
+  log "Checking prerequisites"
+  require_cmd git
+  require_cmd node
+  require_cmd npm
+
+  local major
+  major="$(node_major)"
+  [[ "$major" -ge 20 ]] || die "Node.js 20+ is required. Current major version: $major"
+
+  if command -v docker >/dev/null 2>&1; then
+    docker compose version >/dev/null 2>&1 || warn "Docker Compose v2 was not detected. yclaw doctor will fail for Docker installs until this is fixed."
+  else
+    warn "Docker was not detected. yclaw doctor will fail for Docker Compose installs until Docker is installed and running."
+  fi
+}
+
+ensure_checkout() {
+  log "Preparing YCLAW checkout at $YCLAW_DIR"
+  if [[ -d "$YCLAW_DIR/.git" ]]; then
+    cd "$YCLAW_DIR"
+    if [[ -n "$(git status --porcelain)" ]]; then
+      die "$YCLAW_DIR has local changes. Commit/stash them or choose another --dir."
+    fi
+    git fetch origin
+    git checkout "$YCLAW_BRANCH"
+    git pull --ff-only origin "$YCLAW_BRANCH"
+  elif [[ -e "$YCLAW_DIR" ]]; then
+    die "$YCLAW_DIR already exists and is not a git checkout. Choose another --dir."
+  else
+    mkdir -p "$(dirname "$YCLAW_DIR")"
+    git clone --branch "$YCLAW_BRANCH" "$YCLAW_REPO" "$YCLAW_DIR"
+    cd "$YCLAW_DIR"
+  fi
+}
+
+build_cli() {
+  log "Installing dependencies"
+  npm ci
+
+  log "Building installer CLI"
+  npm run build --workspace=packages/cli
+}
+
+run_init() {
+  log "Generating YCLAW configuration"
+  local args=()
+  [[ "$NON_INTERACTIVE" -eq 1 ]] && args+=(--non-interactive)
+  [[ "$FORCE_INIT" -eq 1 ]] && args+=(--force)
+
+  if [[ "$NON_INTERACTIVE" -eq 0 && ! -r /dev/tty ]]; then
+    die "Interactive init needs a terminal. Rerun with --non-interactive or run this installer from a real shell."
+  fi
+
+  run_tty npx --no-install yclaw init --preset "$YCLAW_PRESET" "${args[@]}"
+}
+
+print_env_guidance() {
+  cat <<'GUIDANCE'
+
+Before deployment, .env must contain real values for:
+  - one LLM key: ANTHROPIC_API_KEY, OPENAI_API_KEY, or OPENROUTER_API_KEY
+  - GITHUB_OWNER and GITHUB_REPO for the default managed repo
+  - YCLAW_REPOS for every repo AO should manage initially
+  - GitHub App credentials: GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, GITHUB_APP_INSTALLATION_ID
+    or GITHUB_TOKEN for local-only testing
+  - GITHUB_WEBHOOK_SECRET, also configured on the GitHub App webhook
+
+The installer will run doctor now. doctor must pass before deployment.
+GUIDANCE
+}
+
+run_doctor() {
+  log "Running health preflight"
+  npx --no-install yclaw doctor
+}
+
+deploy() {
+  log "Deploying YCLAW"
+  npx --no-install yclaw deploy --detach --bootstrap-output-file ./yclaw-root-bootstrap.json </dev/null
+  npx --no-install yclaw status || true
+}
+
+main() {
+  ensure_prerequisites
+  ensure_checkout
+  build_cli
+  run_init
+  print_env_guidance
+
+  if ! run_doctor; then
+    cat <<EOF
+
+YCLAW was initialized but not deployed because doctor failed.
+
+Fix .env, then run:
+  cd "$YCLAW_DIR"
+  npx --no-install yclaw doctor
+  npx --no-install yclaw deploy --detach --bootstrap-output-file ./yclaw-root-bootstrap.json
+EOF
+    exit 1
+  fi
+
+  if [[ "$NO_DEPLOY" -eq 1 ]]; then
+    log "doctor passed. Deployment skipped because --no-deploy was set."
+    exit 0
+  fi
+
+  if [[ "$YES" -eq 1 ]] || prompt_yes_no "doctor passed. Deploy now?"; then
+    deploy
+  else
+    cat <<EOF
+
+doctor passed. Deploy when ready:
+  cd "$YCLAW_DIR"
+  npx --no-install yclaw deploy --detach --bootstrap-output-file ./yclaw-root-bootstrap.json
+EOF
+  fi
+}
+
+main "$@"

--- a/packages/cli/src/generators/env-file.ts
+++ b/packages/cli/src/generators/env-file.ts
@@ -68,6 +68,7 @@ export function generateEnvFile(plan: ResolvedInitPlan): string {
         'GITHUB_APP_PRIVATE_KEY',
         'GITHUB_APP_INSTALLATION_ID',
         'GITHUB_TOKEN',
+        'GITHUB_WEBHOOK_SECRET',
       ],
     },
     {

--- a/packages/cli/src/plan/resolve.ts
+++ b/packages/cli/src/plan/resolve.ts
@@ -135,12 +135,13 @@ function buildEnv(state: WizardState): Record<string, string> {
 
   // GitHub repo identity is required for real work. Leave blank for the wizard
   // to collect/fill later instead of falling back to stale fork defaults.
-  env.GITHUB_OWNER = '';
-  env.GITHUB_REPO = '';
+  env.GITHUB_OWNER = state.credentials.GITHUB_OWNER ?? '';
+  env.GITHUB_REPO = state.credentials.GITHUB_REPO ?? '';
   env.GITHUB_APP_ID = state.credentials.GITHUB_APP_ID ?? '';
   env.GITHUB_APP_PRIVATE_KEY = state.credentials.GITHUB_APP_PRIVATE_KEY ?? '';
   env.GITHUB_APP_INSTALLATION_ID = state.credentials.GITHUB_APP_INSTALLATION_ID ?? '';
   env.GITHUB_TOKEN = state.credentials.GITHUB_TOKEN ?? '';
+  env.GITHUB_WEBHOOK_SECRET = state.credentials.GITHUB_WEBHOOK_SECRET ?? randomHex(32);
 
   // Docker Compose profiles — bundled infrastructure by default
   if (state.deployment.target === 'docker-compose') {

--- a/packages/cli/src/wizard/runner.ts
+++ b/packages/cli/src/wizard/runner.ts
@@ -107,7 +107,13 @@ export function runNonInteractive(presetName: string): ResolvedInitPlan {
     'TWITTER_APP_SECRET',
     'TWITTER_ACCESS_TOKEN',
     'TWITTER_ACCESS_SECRET',
+    'GITHUB_OWNER',
+    'GITHUB_REPO',
+    'GITHUB_APP_ID',
+    'GITHUB_APP_PRIVATE_KEY',
+    'GITHUB_APP_INSTALLATION_ID',
     'GITHUB_TOKEN',
+    'GITHUB_WEBHOOK_SECRET',
   ]);
 
   const credentials: Record<string, string> = {};

--- a/packages/cli/tests/generators.test.ts
+++ b/packages/cli/tests/generators.test.ts
@@ -64,6 +64,12 @@ describe('generateEnvFile', () => {
     expect(env).toMatch(/EVENT_BUS_SECRET=[0-9a-f]{64}/);
   });
 
+  it('includes GitHub webhook secret for doctor readiness', () => {
+    const plan = resolveInitPlan(getPreset('local-demo'));
+    const env = generateEnvFile(plan);
+    expect(env).toMatch(/GITHUB_WEBHOOK_SECRET=[0-9a-f]{64}/);
+  });
+
   it('includes Mission Control auth secret for docker-compose installs', () => {
     const plan = resolveInitPlan(getPreset('local-demo'));
     const env = generateEnvFile(plan);

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 import { runNonInteractive } from '../src/wizard/runner.js';
 import { generateConfigYaml } from '../src/generators/config-yaml.js';
@@ -6,6 +6,34 @@ import { generateEnvFile } from '../src/generators/env-file.js';
 import { generateDockerCompose } from '../src/generators/docker-compose.js';
 import { CliConfigSchema } from '../src/schema/cli-config-schema.js';
 import { YclawConfigSchema } from '@yclaw/core/infrastructure';
+
+const GITHUB_ENV_KEYS = [
+  'GITHUB_OWNER',
+  'GITHUB_REPO',
+  'GITHUB_APP_ID',
+  'GITHUB_APP_PRIVATE_KEY',
+  'GITHUB_APP_INSTALLATION_ID',
+  'GITHUB_TOKEN',
+  'GITHUB_WEBHOOK_SECRET',
+];
+
+const originalEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of GITHUB_ENV_KEYS) {
+    originalEnv[key] = process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of GITHUB_ENV_KEYS) {
+    if (originalEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalEnv[key];
+    }
+  }
+});
 
 describe('Non-interactive init', () => {
   it('local-demo: produces valid config + env + compose', () => {
@@ -88,5 +116,22 @@ describe('Non-interactive init', () => {
   it('aws-production: secrets provider is env (not aws-secrets-manager)', () => {
     const plan = runNonInteractive('aws-production');
     expect(plan.config.secrets.provider).toBe('env');
+  });
+
+  it('passes GitHub readiness values from environment into generated env', () => {
+    process.env.GITHUB_OWNER = 'ExampleOrg';
+    process.env.GITHUB_REPO = 'example-repo';
+    process.env.GITHUB_APP_ID = '12345';
+    process.env.GITHUB_APP_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----';
+    process.env.GITHUB_APP_INSTALLATION_ID = '67890';
+    process.env.GITHUB_WEBHOOK_SECRET = 'from-env-webhook-secret';
+
+    const plan = runNonInteractive('local-demo');
+
+    expect(plan.env.GITHUB_OWNER).toBe('ExampleOrg');
+    expect(plan.env.GITHUB_REPO).toBe('example-repo');
+    expect(plan.env.GITHUB_APP_ID).toBe('12345');
+    expect(plan.env.GITHUB_APP_INSTALLATION_ID).toBe('67890');
+    expect(plan.env.GITHUB_WEBHOOK_SECRET).toBe('from-env-webhook-secret');
   });
 });

--- a/packages/cli/tests/install-script.test.ts
+++ b/packages/cli/tests/install-script.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../..');
+const INSTALL_SCRIPT = resolve(REPO_ROOT, 'install.sh');
+
+describe('install.sh bootstrap contract', () => {
+  it('exists as an executable root bootstrap script', () => {
+    const mode = statSync(INSTALL_SCRIPT).mode;
+    expect(mode & 0o111).not.toBe(0);
+  });
+
+  it('clones, builds the local CLI, runs doctor before deploy, and uses deploy only after a passing doctor', () => {
+    const script = readFileSync(INSTALL_SCRIPT, 'utf8');
+
+    expect(script).toContain('git clone');
+    expect(script).toContain('npm ci');
+    expect(script).toContain('npm run build --workspace=packages/cli');
+    expect(script).toContain('npx --no-install yclaw init');
+    expect(script).toContain('npx --no-install yclaw doctor');
+    expect(script).toContain('npx --no-install yclaw deploy');
+
+    const doctorIndex = script.indexOf('npx --no-install yclaw doctor');
+    const deployIndex = script.indexOf('npx --no-install yclaw deploy');
+    expect(doctorIndex).toBeGreaterThan(-1);
+    expect(deployIndex).toBeGreaterThan(doctorIndex);
+    expect(script).toContain('doctor must pass before deployment');
+  });
+});


### PR DESCRIPTION
## Summary
- add root install.sh for the documented one-line GitHub install path
- gate deployment behind yclaw doctor so failed credentials/config stop before containers start
- pass GitHub readiness env into non-interactive init and generate GITHUB_WEBHOOK_SECRET
- update README/quickstart docs and add installer/env regression tests

## Verification
- npx vitest run packages/cli/tests/generators.test.ts packages/cli/tests/init.test.ts packages/cli/tests/install-script.test.ts
- ./install.sh --help
- bash -n install.sh
- npm run build --workspace=packages/cli
- npm run typecheck
- npm run validate-configs --workspace=packages/core
- npm test
- npm run build